### PR TITLE
Sync test case changes with files_primary_s3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,8 +39,6 @@ pipeline:
   test-scality:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
-    environment:
-      - RUN_OBJECTSTORE_TESTS=1
     commands:
       - cp tests/drone/scality.config.php /drone/server/config
       - wait-for-it scality:8000
@@ -53,8 +51,6 @@ pipeline:
   test-ceph:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
-    environment:
-      - RUN_OBJECTSTORE_TESTS=1
     commands:
       - cp tests/drone/ceph.config.php /drone/server/config
       - wait-for-it ceph:80


### PR DESCRIPTION
## Motivation
https://github.com/owncloud/core/pull/30781 removes the necessity to rely on environment variables for testing objectstore - but resorts to using the configuration