### PR TITLE
Run acceptance tests without ones that require extra apps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,6 +100,7 @@ pipeline:
       - TEST_SERVER_URL=http://server/
       - TEST_SERVER_FED_URL=http://federated/
       - OC_TEST_ON_OBJECTSTORE=1
+      - BEHAT_FILTER_TAGS=~@app-required&&~@skip&&~@masterkey_encryption
     commands:
     - cd /drone/server
     - chmod +x ./tests/drone/test-api-acceptance.sh
@@ -126,7 +127,7 @@ pipeline:
     commands:
       - cd /drone/server
       - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
-      - bash tests/travis/start_ui_tests.sh --remote --all-suites
+      - bash tests/travis/start_ui_tests.sh --tags "~@app-required&&~@skip" --remote --all-suites
     when:
       matrix:
         TEST_SUITE: selenium


### PR DESCRIPTION
Run the "whole" API and webUI acceptance tests by specifying the tags of scenarios that we do not want to run:
``~@app-required`` - do not run scenarios that require some other app to be cloned/installed/enabled

``~@skip`` - do not run skipped scenarios (these are usually ones that demonstrate a bug waiting to be fixed

``~@masterkey_encryption`` - do not run scenarios that switch masterkey encryption (these do not work in the normal flow of API acceptance tests)

See also #78 for an alternate approach.
