### PR TITLE
use composer cache for core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,8 @@ pipeline:
     db_type: ${DB_TYPE}
     db_host: ${DB_HOST}
     git_reference: ${CORE_BRANCH}
+    environment:
+      - COMPOSER_CACHE_DIR=composer
 
   php-cs-fixer:
     image: owncloudci/php:${PHP_VERSION}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .php_cs.cache
+composer


### PR DESCRIPTION
use the restored composer cache when installing core from a source branch