### PR TITLE
Use core acceptance tests run.sh

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -141,18 +141,17 @@ pipeline:
     environment:
       - BROWSER=chrome
       - SELENIUM_HOST=selenium
-      - SRV_HOST_NAME=server
-      - SRV_HOST_PORT=80
-      - REMOTE_FED_SRV_HOST_NAME=federated
-      - REMOTE_FED_SRV_HOST_PORT=80
-      - SKELETON_DIR=/drone/server/tests/acceptance/webUISkeleton
       - SELENIUM_PORT=4444
+      - TEST_SERVER_URL=http://server
+      - TEST_SERVER_FED_URL=http://federated
+      - SKELETON_DIR=/drone/server/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
-      - cd /drone/server
+      - cd /drone/server/tests/acceptance
       - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
-      - bash tests/travis/start_ui_tests.sh --tags "~@app-required&&~@skip" --remote --all-suites
+      - chmod +x run.sh
+      - su-exec www-data ./run.sh --remote --type webUI --tags "~@app-required&&~@skip"
     when:
       matrix:
         TEST_SUITE: selenium

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,41 @@ workspace:
 branches: [ master, release, release/* ]
 
 pipeline:
+  install-fed-server:
+    image: owncloudci/core
+    pull: true
+    version: ${FEDERATION_OC_VERSION}
+    core_path: /drone/fed-server
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
+  configure-federation-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /drone/fed-server
+      - php occ a:l
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=server
+      - php occ config:system:set trusted_domains 2 --value=federated
+      - php occ log:manage --level 0
+      - php occ config:list
+      - echo "export TEST_SERVER_FED_URL=http://federated" > /drone/saved-settings.sh
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
+  fix-permissions-federation-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - chown www-data /drone/fed-server -R
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
   restore:
     image: plugins/s3-cache:1
     pull: true
@@ -117,20 +152,41 @@ pipeline:
       matrix:
         PREPARE_ACCEPTANCE: true
 
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+     - tail -f /drone/server/data/owncloud.log
+    when:
+      matrix:
+        OWNCLOUD_LOG: true
+
+  federated-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+     - tail -f /drone/fed-server/data/owncloud.log
+    when:
+      matrix:
+        OWNCLOUD_LOG: true
+        USE_FEDERATED_SERVER: true
 
   api-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
       - TEST_SERVER_URL=http://server/
-      - TEST_SERVER_FED_URL=http://federated/
       - OC_TEST_ON_OBJECTSTORE=1
       - BEHAT_FILTER_TAGS=~@app-required&&~@skip&&~@masterkey_encryption
     commands:
-    - cd /drone/server
-    - chmod +x ./tests/drone/test-acceptance.sh
-    - chmod +x ./tests/acceptance/run.sh
-    - ./tests/drone/test-acceptance.sh
+      - touch /drone/saved-settings.sh
+      - . /drone/saved-settings.sh
+      - cd /drone/server
+      - chmod +x ./tests/drone/test-acceptance.sh
+      - chmod +x ./tests/acceptance/run.sh
+      - ./tests/drone/test-acceptance.sh
     when:
       matrix:
         TEST_SUITE: api
@@ -143,11 +199,12 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
-      - TEST_SERVER_FED_URL=http://federated
       - SKELETON_DIR=/drone/server/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
+      - touch /drone/saved-settings.sh
+      - . /drone/saved-settings.sh
       - cd /drone/server/tests/acceptance
       - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
       - chmod +x run.sh
@@ -156,7 +213,6 @@ pipeline:
       matrix:
         TEST_SUITE: selenium
 
-
   print-log:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -164,6 +220,8 @@ pipeline:
       - cat /drone/server/data/owncloud.log
     when:
       status:  [ failure ]
+      matrix:
+        TEST_SUITE: phpunit
 
   rebuild:
     image: plugins/s3-cache:1
@@ -238,7 +296,7 @@ services:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - APACHE_WEBROOT=/drone/server
+      - APACHE_WEBROOT=/drone/fed-server
     command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
     when:
       matrix:
@@ -348,20 +406,24 @@ matrix:
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       TEST_SUITE: selenium
       DB_TYPE: mysql
       DB_HOST: mysql
       STORAGE: ceph
+      OWNCLOUD_LOG: true
 
     - PHP_VERSION: 7.1
       CORE_BRANCH: master
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
       TEST_SUITE: selenium
       DB_TYPE: mysql
       DB_HOST: mysql
       STORAGE: ceph
+      OWNCLOUD_LOG: true
 
     # API
     - PHP_VERSION: 7.1
@@ -369,17 +431,21 @@ matrix:
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       TEST_SUITE: api
       DB_TYPE: mysql
       DB_HOST: mysql
       STORAGE: ceph
+      OWNCLOUD_LOG: true
 
     - PHP_VERSION: 7.1
       CORE_BRANCH: master
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
       TEST_SUITE: api
       DB_TYPE: mysql
       DB_HOST: mysql
       STORAGE: ceph
+      OWNCLOUD_LOG: true


### PR DESCRIPTION
and use a proper separate federated server, like is done in core nowadays.

This is "a good thing" and also needed to make CI pass, because some core scenarios now create ``user1`` on both LOCAL and REMOTE servers and expect them to be 2 independent users. That passes only if the REMOTE federated server is truly a separate server.

Thanks to @individual-it for the code to do this in core, which I was able to easily steal and put here also. This is where "drone include files" would be useful, to suck in common snippets of ``drone.yml`` code that are the same in apps.