### PR TITLE
Rename command s3:ls to s3:list

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ This extension is the successor of the [ownCloud Objectstore App](https://market
 		<filesystem/>
 	</types>
 	<commands>
-		<command>OCA\Files_Primary_S3\Command\ls</command>
+		<command>OCA\Files_Primary_S3\Command\s3List</command>
 		<command>OCA\Files_Primary_S3\Command\createBucket</command>
 	</commands>
 </info>

--- a/lib/command/s3list.php
+++ b/lib/command/s3list.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-class ls extends Command {
+class s3List extends Command {
 
 	/** @var IConfig */
 	private $config;
@@ -43,7 +43,7 @@ class ls extends Command {
 
 	protected function configure() {
 		$this
-			->setName('s3:ls')
+			->setName('s3:list')
 			->setDescription('List objects, buckets or versions of an object')
 			->addArgument('bucket', InputArgument::OPTIONAL, 'Name of the bucket; it`s objects will be listed')
 			->addArgument('object', InputArgument::OPTIONAL, 'Key of the object; it`s versions will be listed');


### PR DESCRIPTION
Refrences: https://github.com/owncloud/files_primary_s3/issues/111 (Rename occ command s3:ls to s3:list for better identification)

This PR does two things:
- renaming the file ``ls.php`` --> ``s3list.php``
- renaming the command from ``s3:ll`` --> ``s3:list``

Documentation relevant, will file a doc issue asap 
