### PR TITLE
Use ceph docker container from owncloudci organisation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ services:
         STORAGE: scality
 
   ceph:
-    image: ceph/demo:tag-build-master-jewel-ubuntu-16.04
+    image: owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04
     pull: true
     environment:
       - NETWORK_AUTO_DETECT=4


### PR DESCRIPTION
As the official demo containers are dropped - we temporarily provide the container via `owncloudci/ceph:tag` 