### PR TITLE
Create local_storage folder when running API acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -135,6 +135,16 @@ pipeline:
         TEST_SUITE: phpunit
         STORAGE: ceph
 
+  setup-api-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      # pre-create local_storage so configure-server will set its owner appropriately
+      - mkdir -p /drone/server/tests/acceptance/work/local_storage
+    when:
+      matrix:
+        TEST_SUITE: api
+
   configure-server:
     image: owncloudci/php:${PHP_VERSION}
     pull: true


### PR DESCRIPTION
The core ``tests/drone/test-acceptance.sh`` script no longer runs as ``www-data``.
So it has no priv to create the ``tests/acceptance/work/local_storage`` folder.
Create it earlier in the drone pipeline so it is available, the same as is done in core.