### PR TITLE
drop unavailable autocreate option

### DIFF
--- a/tests/drone/ceph.config.php
+++ b/tests/drone/ceph.config.php
@@ -5,7 +5,6 @@ $CONFIG = [
 		'arguments' => [
 			// replace with your bucket
 			'bucket' => 'OWNCLOUD',
-			'autocreate' => true,
 			// uncomment to enable server side encryption
 			//'serversideencryption' => 'AES256',
 			'options' => [

--- a/tests/drone/scality.config.php
+++ b/tests/drone/scality.config.php
@@ -5,7 +5,6 @@ $CONFIG = [
 		'arguments' => [
 			// replace with your bucket
 			'bucket' => 'owncloud',
-			'autocreate' => true,
 			// uncomment to enable server side encryption
 			//'serversideencryption' => 'AES256',
 			'options' => [


### PR DESCRIPTION
Within `files_primary_S3` this option is no longer available. Remove the option from the test configuration as it implies it might still have an effect