### PR TITLE
Fix splitting core API tests into parts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -192,10 +192,10 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - cd /drone/server
-      - chmod +x ./tests/drone/test-acceptance.sh
-      - chmod +x ./tests/acceptance/run.sh
-      - ./tests/drone/test-acceptance.sh
+      - cd /drone/server/tests/acceptance
+      - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
+      - chmod +x run.sh
+      - ./run.sh --remote --type api --tags "~@app-required&&~@skip&&~@skipOnStorage:${STORAGE}"
     when:
       matrix:
         TEST_SUITE: api


### PR DESCRIPTION
The drone ``api-acceptance-tests`` pipeline step was running an old ``tests/drone/test-acceptance.sh``
That did not process the splitting of test suites into parts, so all the API tests were running in the first part 1 of 5. Parts 2,3,4,5 were running nothing (and finishing in a few minutes).

Change the drone pipeline step to do similar to ``webui-acceptance-tests``

This reduces the elapsed time for running CI from 3 to 4 hours to about 1.5 hours.

I have checked the drone result, and all the core API suites are being run across the 5 "parts" of core API acceptance tests.