### PR TITLE
loop when creating bucket for testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,7 +122,7 @@ pipeline:
     commands:
       - wait-for-it ceph:80
       - cd /drone/server
-      - php ./occ s3:create-bucket OWNCLOUD --accept-warning
+      - ./apps/files_primary_s3/tests/drone/create-bucket.sh
     when:
       matrix:
         STORAGE: ceph

--- a/tests/drone/create-bucket.sh
+++ b/tests/drone/create-bucket.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ceph in docker starts up OK, but then sometimes takes time to configure
+# CEPH_DEMO_UID. If we try to create the bucket too early, then we get:
+#   Client error response [url] http://ceph/OWNCLOUD [status code]
+#   403 [reason phrase] Forbidden
+
+# Loop trying to create the bucket until success or so long that it is likely
+# there is some other problem.
+for i in {1..10}
+do
+    php ./occ s3:create-bucket OWNCLOUD --accept-warning
+    if [ $? -eq 0 ]
+    then
+        break
+    fi
+    echo "create-bucket failed. Maybe the ceph account is not ready yet."
+    echo "waiting 10 seconds..."
+    sleep 10
+done


### PR DESCRIPTION
Issue #170 

When the ``ceph`` docker starts up, it starts listening on its port. So
```
wait-for-it ceph:80
```
sees that ``ceph`` is up.

The ``ceph`` container also creates ``CEPH_DEMO_UID`` with ``CEPH_DEMO_ACCESS_KEY`` and ``CEPH_DEMO_SECRET_KEY`` but that takes a variable amount of time. So actually the ``CEPH_DEMO_UID`` might not be ready.

This new script ``create-bucket.sh`` loops trying to do the ``occ s3:create-bucket`` until it succeeds, or until it has tried 10 times at 10-second intervals. That should prevent intermittent fails when there is some ``ceph`` delay, but still give up and exit when something really is wrong.