### PR TITLE
Install and run behat from vendor-bin

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,0 +1,17 @@
+{
+    "config" : {
+        "platform": {
+            "php": "5.6.33"
+        }
+    },
+    "require": {
+        "behat/behat": "^3.0",
+        "behat/mink-extension": "^2.2",
+        "behat/mink-goutte-driver": "^1.2",
+        "behat/mink-selenium2-driver": "dev-master",
+        "jarnaiz/behat-junit-formatter": "^1.3",
+        "rdx/behat-variables": "^1.2",
+        "sensiolabs/behat-page-object-extension": "^2.0",
+        "symfony/translation": "^3.4"
+    }
+}


### PR DESCRIPTION
Like done in core PR https://github.com/owncloud/core/pull/34212

Note: this repo does not have any acceptance tests of its own. It only runs acceptance tests from core. But core QA tarball no longer has any pre-installed behat, so we need to set up the ``vendor-bin/behat`` stuff here.