### PR TITLE
Always provide return status for functions

### DIFF
--- a/lib/s3storage.php
+++ b/lib/s3storage.php
@@ -126,10 +126,20 @@ class S3Storage implements IObjectStore, IVersionedObjectStorage {
 		}
 
 		$uploader = new ObjectUploader($this->connection, $this->getBucket(), $urn, $stream, 'private', $opt);
-		$uploader->upload();
+		$status = $uploader->upload();
+		$statusCode = $status->get('@metadata')['statusCode'];
 		if (\is_resource($stream)) {
 			\fclose($stream);
 		}
+
+		/**
+		 * Upload to object storage is successful when status code is 200
+		 */
+		if ($statusCode === 200) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Provide return status for writeObject method.
This would help to know if the upload to
object storage was successful or not.

Signed-off-by: Sujith H <sharidasan@owncloud.com>