### PR TITLE
Use only 1 var in when matrix of drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -127,7 +127,7 @@ pipeline:
       matrix:
         STORAGE: ceph
 
-  test-scality:
+  test-phpunit-scality:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
@@ -136,10 +136,9 @@ pipeline:
       - php ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml
     when:
       matrix:
-        TEST_SUITE: phpunit
-        STORAGE: scality
+        TEST_SUITE: phpunit-scality
 
-  test-ceph:
+  test-phpunit-ceph:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
@@ -148,8 +147,7 @@ pipeline:
       - php ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml
     when:
       matrix:
-        TEST_SUITE: phpunit
-        STORAGE: ceph
+        TEST_SUITE: phpunit-ceph
 
   configure-server:
     image: owncloudci/php:${PHP_VERSION}
@@ -187,7 +185,6 @@ pipeline:
      - tail -f /drone/fed-server/data/owncloud.log
     when:
       matrix:
-        OWNCLOUD_LOG: true
         USE_FEDERATED_SERVER: true
 
   core-api-acceptance-tests:
@@ -233,16 +230,6 @@ pipeline:
     when:
       matrix:
         TEST_SUITE: core-web-acceptance
-
-  print-log:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cat /drone/server/data/owncloud.log
-    when:
-      status:  [ failure ]
-      matrix:
-        TEST_SUITE: phpunit
 
   rebuild:
     image: plugins/s3-cache:1
@@ -366,74 +353,83 @@ matrix:
     - STORAGE: ceph
       PHP_VERSION: 7.0
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-ceph
       FLUSH_CACHE: true
       REBUILT_CACHE: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       PHP_VERSION: 7.0
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       STORAGE_CONFIG_SUFFIX: .multibucket
       PHP_VERSION: 7.0
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     # 7.1
     - STORAGE: ceph
       PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-ceph
       FLUSH_CACHE: true
       REBUILT_CACHE: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       STORAGE_CONFIG_SUFFIX: .multibucket
       PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     # 7.2
     - STORAGE: ceph
       PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-ceph
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     - STORAGE: scality
       STORAGE_CONFIG_SUFFIX: .multibucket
       PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
+      TEST_SUITE: phpunit-scality
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      OWNCLOUD_LOG: true
 
     # acceptance tests
     # UI master


### PR DESCRIPTION
The new drone tries to auto-convert the old drone format. It seems that when there are multiple variables mentioned in the `when` section of a step, it is doing something in the auto-conversion that causes:

`linter: duplicate step names`

I guess that it might be putting the step twice into the converted matrix.

The changes in this PR work-around the "feature".