### PR TITLE
Use scoper to namespace dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,6 +106,7 @@ pipeline:
         NEED_INSTALL_APP: true
 
   build-app:
+    # scoper requires php 7.2 - that is why the app is built on a php7.2 image
     image: owncloudci/php:7.2
     pull: true
     environment:
@@ -120,7 +121,7 @@ pipeline:
         NEED_INSTALL_BUILT_APP: true
 
   install-built-app:
-    #scope requires php 7.2
+
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -490,519 +491,519 @@ matrix:
 #      NEED_INSTALL_APP: true
 #      OWNCLOUD_LOG: true
 #
-#    # acceptance tests
-#    # UI master
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 1
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 2
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 3
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 4
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 5
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 6
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 7
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 8
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 9
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 10
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 11
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 12
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 13
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 14
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 15
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 16
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 17
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 18
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 19
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-web-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 20
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    # API master
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 1
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 2
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 3
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 4
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 5
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 6
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 7
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 8
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 9
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 10
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 11
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 12
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 13
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
-#    - PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      PREPARE_ACCEPTANCE: true
-#      NEED_SERVER: true
-#      USE_FEDERATED_SERVER: true
-#      FEDERATION_OC_VERSION: daily-master-qa
-#      TEST_SUITE: core-api-acceptance
-#      DB_TYPE: mysql
-#      DB_HOST: mysql
-#      STORAGE: ceph
-#      OWNCLOUD_LOG: true
-#      PART: 14
-#      NEED_CORE: true
-#      NEED_INSTALL_BUILT_APP: true
-#
+    # acceptance tests
+    # UI master
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 1
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 2
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 3
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 4
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 5
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 6
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 7
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 8
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 9
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 10
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 11
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 12
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 13
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 14
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 15
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 16
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 17
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 18
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 19
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-web-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 20
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    # API master
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 1
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 2
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 3
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 4
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 5
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 6
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 7
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 8
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 9
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 10
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 11
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 12
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 13
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      PREPARE_ACCEPTANCE: true
+      NEED_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-master-qa
+      TEST_SUITE: core-api-acceptance
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      STORAGE: ceph
+      OWNCLOUD_LOG: true
+      PART: 14
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
       PREPARE_ACCEPTANCE: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -373,14 +373,14 @@ services:
 
 matrix:
   include:
-#    # owncloud-coding-standard
-#    - PHP_VERSION: 7.2
-#      STORAGE: "does not matter"
-#      TEST_SUITE: owncloud-coding-standard
-#
-#    - PHP_VERSION: 7.0
-#      STORAGE: "does not matter"
-#      TEST_SUITE: owncloud-coding-standard
+    # owncloud-coding-standard
+    - PHP_VERSION: 7.2
+      STORAGE: "does not matter"
+      TEST_SUITE: owncloud-coding-standard
+
+    - PHP_VERSION: 7.0
+      STORAGE: "does not matter"
+      TEST_SUITE: owncloud-coding-standard
 #
 #    # unit tests
 #    # 7.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -155,7 +155,7 @@ pipeline:
     commands:
       - wait-for-it ceph:80
       - cd /drone/server
-      - ./$DRONE_WORKSPACE/tests/drone/create-bucket.sh
+      - $DRONE_WORKSPACE/tests/drone/create-bucket.sh
     when:
       matrix:
         STORAGE: ceph

--- a/.drone.yml
+++ b/.drone.yml
@@ -111,24 +111,27 @@ pipeline:
     pull: true
     environment:
       - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
-      - NPM_CONFIG_CACHE=/drone/files_primary_s3/.cache/npm
-      - YARN_CACHE_FOLDER=/drone/files_primary_s3/.cache/yarn
-      - bower_storage__packages=/drone/files_primary_s3/.cache/bower
     commands:
       - make dist
     when:
       matrix:
-        NEED_INSTALL_BUILT_APP: true
+        BUILT_APP: true
 
-  install-built-app:
-
-    image: owncloudci/php:${PHP_VERSION}
+  build-app-qa:
+    # scoper requires php 7.2 - that is why the app is built on a php7.2 image
+    image: owncloudci/php:7.2
     pull: true
     environment:
       - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
-      - NPM_CONFIG_CACHE=/drone/files_primary_s3/.cache/npm
-      - YARN_CACHE_FOLDER=/drone/files_primary_s3/.cache/yarn
-      - bower_storage__packages=/drone/files_primary_s3/.cache/bower
+    commands:
+      - make dist-qa
+    when:
+      matrix:
+        BUILT_APP_QA: true
+
+  install-built-app:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
     commands:
       - mkdir -p /drone/server/config
       - php /drone/server/occ market:install --local $DRONE_WORKSPACE/build/artifacts/appstore/files_primary_s3.tar.gz
@@ -167,6 +170,7 @@ pipeline:
     commands:
       - wait-for-it scality:8000
       - cd /drone/server
+      - cp -r $DRONE_WORKSPACE/tests apps-external/files_primary_s3
       - php ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml
     when:
       matrix:
@@ -178,6 +182,7 @@ pipeline:
     commands:
       - wait-for-it ceph:80
       - cd /drone/server
+      - cp -r $DRONE_WORKSPACE/tests apps-external/files_primary_s3
       - php ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml
     when:
       matrix:
@@ -391,6 +396,7 @@ matrix:
       FLUSH_CACHE: true
       REBUILT_CACHE: true
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -399,6 +405,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -408,6 +415,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -419,6 +427,7 @@ matrix:
       FLUSH_CACHE: true
       REBUILT_CACHE: true
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -427,6 +436,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -436,6 +446,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -445,6 +456,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-ceph
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -453,6 +465,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -462,6 +475,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -471,6 +485,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-ceph
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -479,6 +494,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -488,6 +504,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit-scality
       NEED_CORE: true
+      BUILT_APP_QA: true
       NEED_INSTALL_BUILT_APP: true
       OWNCLOUD_LOG: true
 
@@ -506,6 +523,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 1
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -521,6 +539,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 2
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -536,6 +555,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 3
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -551,6 +571,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 4
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -566,6 +587,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 5
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -581,6 +603,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 6
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -596,6 +619,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 7
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -611,6 +635,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 8
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -626,6 +651,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 9
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -641,6 +667,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 10
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -656,6 +683,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 11
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -671,6 +699,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 12
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -686,6 +715,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 13
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -701,6 +731,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 14
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -716,6 +747,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 15
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -731,6 +763,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 16
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -746,6 +779,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 17
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -761,6 +795,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 18
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -776,6 +811,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 19
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -791,6 +827,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 20
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     # API master
@@ -807,6 +844,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 1
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -822,6 +860,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 2
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -837,6 +876,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 3
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -852,6 +892,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 4
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -867,6 +908,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 5
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -882,6 +924,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 6
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -897,6 +940,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 7
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -912,6 +956,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 8
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -927,6 +972,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 9
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -942,6 +988,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 10
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -957,6 +1004,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 11
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -972,6 +1020,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 12
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -987,6 +1036,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 13
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -1002,6 +1052,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 14
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
@@ -1017,4 +1068,5 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 15
       NEED_CORE: true
+      BUILT_APP: true
       NEED_INSTALL_BUILT_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,8 +105,7 @@ pipeline:
       matrix:
         NEED_INSTALL_APP: true
 
-  install-built-app:
-    #scope requires php 7.2
+  build-app:
     image: owncloudci/php:7.2
     pull: true
     environment:
@@ -116,12 +115,23 @@ pipeline:
       - bower_storage__packages=/drone/files_primary_s3/.cache/bower
     commands:
       - make dist
-      - rm -rf appinfo lib vendor
+    when:
+      matrix:
+        NEED_INSTALL_BUILT_APP: true
+
+  install-built-app:
+    #scope requires php 7.2
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
+      - NPM_CONFIG_CACHE=/drone/files_primary_s3/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/files_primary_s3/.cache/yarn
+      - bower_storage__packages=/drone/files_primary_s3/.cache/bower
+    commands:
       - mkdir -p /drone/server/config
       - cp tests/drone/${STORAGE}${STORAGE_CONFIG_SUFFIX}.config.php /drone/server/config
-      - cd /drone/server/apps-external
-      - mv $DRONE_WORKSPACE/build/artifacts/appstore/files_primary_s3.tar.gz .
-      - tar xfz files_primary_s3.tar.gz
+      - php /drone/server/occ market:install --local $DRONE_WORKSPACE/build/artifacts/appstore/files_primary_s3.tar.gz
       - php /drone/server/occ app:enable files_primary_s3
     when:
       matrix:

--- a/.drone.yml
+++ b/.drone.yml
@@ -381,116 +381,116 @@ matrix:
     - PHP_VERSION: 7.0
       STORAGE: "does not matter"
       TEST_SUITE: owncloud-coding-standard
-#
-#    # unit tests
-#    # 7.0
-#    - STORAGE: ceph
-#      PHP_VERSION: 7.0
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-ceph
-#      FLUSH_CACHE: true
-#      REBUILT_CACHE: true
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      PHP_VERSION: 7.0
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      STORAGE_CONFIG_SUFFIX: .multibucket
-#      PHP_VERSION: 7.0
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    # 7.1
-#    - STORAGE: ceph
-#      PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-ceph
-#      FLUSH_CACHE: true
-#      REBUILT_CACHE: true
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      STORAGE_CONFIG_SUFFIX: .multibucket
-#      PHP_VERSION: 7.1
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    # 7.2
-#    - STORAGE: ceph
-#      PHP_VERSION: 7.2
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-ceph
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      PHP_VERSION: 7.2
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      STORAGE_CONFIG_SUFFIX: .multibucket
-#      PHP_VERSION: 7.2
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    # 7.3
-#    - STORAGE: ceph
-#      PHP_VERSION: 7.3
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-ceph
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      PHP_VERSION: 7.3
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
-#    - STORAGE: scality
-#      STORAGE_CONFIG_SUFFIX: .multibucket
-#      PHP_VERSION: 7.3
-#      OC_VERSION: daily-master-qa
-#      TEST_SUITE: phpunit-scality
-#      NEED_CORE: true
-#      NEED_INSTALL_APP: true
-#      OWNCLOUD_LOG: true
-#
+
+    # unit tests
+    # 7.0
+    - STORAGE: ceph
+      PHP_VERSION: 7.0
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-ceph
+      FLUSH_CACHE: true
+      REBUILT_CACHE: true
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      PHP_VERSION: 7.0
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      STORAGE_CONFIG_SUFFIX: .multibucket
+      PHP_VERSION: 7.0
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    # 7.1
+    - STORAGE: ceph
+      PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-ceph
+      FLUSH_CACHE: true
+      REBUILT_CACHE: true
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      STORAGE_CONFIG_SUFFIX: .multibucket
+      PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    # 7.2
+    - STORAGE: ceph
+      PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-ceph
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      STORAGE_CONFIG_SUFFIX: .multibucket
+      PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    # 7.3
+    - STORAGE: ceph
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-ceph
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
+    - STORAGE: scality
+      STORAGE_CONFIG_SUFFIX: .multibucket
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit-scality
+      NEED_CORE: true
+      NEED_INSTALL_BUILT_APP: true
+      OWNCLOUD_LOG: true
+
     # acceptance tests
     # UI master
     - PHP_VERSION: 7.1

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,9 +130,9 @@ pipeline:
       - bower_storage__packages=/drone/files_primary_s3/.cache/bower
     commands:
       - mkdir -p /drone/server/config
-      - cp tests/drone/${STORAGE}${STORAGE_CONFIG_SUFFIX}.config.php /drone/server/config
       - php /drone/server/occ market:install --local $DRONE_WORKSPACE/build/artifacts/appstore/files_primary_s3.tar.gz
       - php /drone/server/occ app:enable files_primary_s3
+      - cp tests/drone/${STORAGE}${STORAGE_CONFIG_SUFFIX}.config.php /drone/server/config
     when:
       matrix:
         NEED_INSTALL_BUILT_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -104,6 +104,31 @@ pipeline:
       matrix:
         NEED_INSTALL_APP: true
 
+  install-built-app:
+    #scope requires php 7.2
+    image: owncloudci/php:7.2
+    pull: true
+    environment:
+      - COMPOSER_HOME=/drone/server/apps/files_primary_s3/.cache/composer
+      - NPM_CONFIG_CACHE=/drone/server/apps/files_primary_s3/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/server/apps/files_primary_s3/.cache/yarn
+      - bower_storage__packages=/drone/server/apps/files_primary_s3/.cache/bower
+    commands:
+      - make dist
+      - rm -rf appinfo lib vendor
+      - mkdir -p /drone/server/config
+      - cp tests/drone/${STORAGE}${STORAGE_CONFIG_SUFFIX}.config.php /drone/server/config
+      - cd /drone/server/apps-external
+      - mv /drone/server/apps/files_primary_s3/build/artifacts/appstore/files_primary_s3.tar.gz .
+      - tar xfz files_primary_s3.tar.gz
+      - php /drone/server/occ app:enable files_primary_s3
+      - ls -al /drone/server
+      - ls -al /drone/server/apps
+      - ls -al /drone/server/apps-external
+    when:
+      matrix:
+        NEED_INSTALL_BUILT_APP: true
+
   prepare-bucket-scality:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -472,7 +497,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 1
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -487,7 +512,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 2
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -502,7 +527,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 3
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -517,7 +542,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 4
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -532,7 +557,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 5
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -547,7 +572,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 6
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -562,7 +587,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 7
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -577,7 +602,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 8
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -592,7 +617,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 9
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -607,7 +632,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 10
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -622,7 +647,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 11
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -637,7 +662,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 12
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -652,7 +677,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 13
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -667,7 +692,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 14
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -682,7 +707,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 15
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -697,7 +722,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 16
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -712,7 +737,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 17
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -727,7 +752,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 18
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -742,7 +767,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 19
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -757,7 +782,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 20
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     # API master
     - PHP_VERSION: 7.1
@@ -773,7 +798,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 1
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -788,7 +813,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 2
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -803,7 +828,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 3
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -818,7 +843,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 4
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -833,7 +858,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 5
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -848,7 +873,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 6
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -863,7 +888,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 7
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -878,7 +903,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 8
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -893,7 +918,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 9
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -908,7 +933,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 10
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -923,7 +948,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 11
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -938,7 +963,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 12
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -953,7 +978,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 13
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -968,7 +993,7 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 14
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -983,4 +1008,4 @@ matrix:
       OWNCLOUD_LOG: true
       PART: 15
       NEED_CORE: true
-      NEED_INSTALL_APP: true
+      NEED_INSTALL_BUILT_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 workspace:
   base: /drone
-  path: server/apps/files_primary_s3
+  path: files_primary_s3
+
 
 branches: [ master, release, release/* ]
 
@@ -52,7 +53,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - COMPOSER_HOME=/drone/server/apps/files_primary_s3/.cache/composer
+      - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
     commands:
       - composer install -n --no-progress
 
@@ -72,11 +73,12 @@ pipeline:
     pull: true
     db_type: ${DB_TYPE}
     db_host: ${DB_HOST}
+    core_path: /drone/server
     environment:
-      - COMPOSER_HOME=/drone/server/apps/files_primary_s3/.cache/composer
-      - NPM_CONFIG_CACHE=/drone/server/apps/files_primary_s3/.cache/npm
-      - YARN_CACHE_FOLDER=/drone/server/apps/files_primary_s3/.cache/yarn
-      - bower_storage__packages=/drone/server/apps/files_primary_s3/.cache/bower
+      - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
+      - NPM_CONFIG_CACHE=/drone/files_primary_s3/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/files_primary_s3/.cache/yarn
+      - bower_storage__packages=/drone/files_primary_s3/.cache/bower
     when:
       matrix:
         NEED_CORE: true
@@ -109,22 +111,19 @@ pipeline:
     image: owncloudci/php:7.2
     pull: true
     environment:
-      - COMPOSER_HOME=/drone/server/apps/files_primary_s3/.cache/composer
-      - NPM_CONFIG_CACHE=/drone/server/apps/files_primary_s3/.cache/npm
-      - YARN_CACHE_FOLDER=/drone/server/apps/files_primary_s3/.cache/yarn
-      - bower_storage__packages=/drone/server/apps/files_primary_s3/.cache/bower
+      - COMPOSER_HOME=/drone/files_primary_s3/.cache/composer
+      - NPM_CONFIG_CACHE=/drone/files_primary_s3/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/files_primary_s3/.cache/yarn
+      - bower_storage__packages=/drone/files_primary_s3/.cache/bower
     commands:
       - make dist
       - rm -rf appinfo lib vendor
       - mkdir -p /drone/server/config
       - cp tests/drone/${STORAGE}${STORAGE_CONFIG_SUFFIX}.config.php /drone/server/config
       - cd /drone/server/apps-external
-      - mv /drone/server/apps/files_primary_s3/build/artifacts/appstore/files_primary_s3.tar.gz .
+      - mv $DRONE_WORKSPACE/build/artifacts/appstore/files_primary_s3.tar.gz .
       - tar xfz files_primary_s3.tar.gz
       - php /drone/server/occ app:enable files_primary_s3
-      - ls -al /drone/server
-      - ls -al /drone/server/apps
-      - ls -al /drone/server/apps-external
     when:
       matrix:
         NEED_INSTALL_BUILT_APP: true
@@ -147,7 +146,7 @@ pipeline:
     commands:
       - wait-for-it ceph:80
       - cd /drone/server
-      - ./apps/files_primary_s3/tests/drone/create-bucket.sh
+      - ./$DRONE_WORKSPACE/tests/drone/create-bucket.sh
     when:
       matrix:
         STORAGE: ceph
@@ -364,637 +363,637 @@ services:
 
 matrix:
   include:
-    # owncloud-coding-standard
-    - PHP_VERSION: 7.2
-      STORAGE: "does not matter"
-      TEST_SUITE: owncloud-coding-standard
-
-    - PHP_VERSION: 7.0
-      STORAGE: "does not matter"
-      TEST_SUITE: owncloud-coding-standard
-
-    # unit tests
-    # 7.0
-    - STORAGE: ceph
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-ceph
-      FLUSH_CACHE: true
-      REBUILT_CACHE: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      STORAGE_CONFIG_SUFFIX: .multibucket
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    # 7.1
-    - STORAGE: ceph
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-ceph
-      FLUSH_CACHE: true
-      REBUILT_CACHE: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      STORAGE_CONFIG_SUFFIX: .multibucket
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    # 7.2
-    - STORAGE: ceph
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-ceph
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      STORAGE_CONFIG_SUFFIX: .multibucket
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    # 7.3
-    - STORAGE: ceph
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-ceph
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    - STORAGE: scality
-      STORAGE_CONFIG_SUFFIX: .multibucket
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit-scality
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      OWNCLOUD_LOG: true
-
-    # acceptance tests
-    # UI master
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 1
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 2
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 3
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 4
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 5
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 6
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 7
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 8
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 9
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 10
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 11
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 12
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 13
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 14
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 15
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 16
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 17
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 18
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 19
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-web-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 20
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    # API master
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 1
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 2
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 3
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 4
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 5
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 6
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 7
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 8
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 9
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 10
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 11
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 12
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 13
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      PREPARE_ACCEPTANCE: true
-      NEED_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      TEST_SUITE: core-api-acceptance
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      STORAGE: ceph
-      OWNCLOUD_LOG: true
-      PART: 14
-      NEED_CORE: true
-      NEED_INSTALL_BUILT_APP: true
-
+#    # owncloud-coding-standard
+#    - PHP_VERSION: 7.2
+#      STORAGE: "does not matter"
+#      TEST_SUITE: owncloud-coding-standard
+#
+#    - PHP_VERSION: 7.0
+#      STORAGE: "does not matter"
+#      TEST_SUITE: owncloud-coding-standard
+#
+#    # unit tests
+#    # 7.0
+#    - STORAGE: ceph
+#      PHP_VERSION: 7.0
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-ceph
+#      FLUSH_CACHE: true
+#      REBUILT_CACHE: true
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      PHP_VERSION: 7.0
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      STORAGE_CONFIG_SUFFIX: .multibucket
+#      PHP_VERSION: 7.0
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    # 7.1
+#    - STORAGE: ceph
+#      PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-ceph
+#      FLUSH_CACHE: true
+#      REBUILT_CACHE: true
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      STORAGE_CONFIG_SUFFIX: .multibucket
+#      PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    # 7.2
+#    - STORAGE: ceph
+#      PHP_VERSION: 7.2
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-ceph
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      PHP_VERSION: 7.2
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      STORAGE_CONFIG_SUFFIX: .multibucket
+#      PHP_VERSION: 7.2
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    # 7.3
+#    - STORAGE: ceph
+#      PHP_VERSION: 7.3
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-ceph
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      PHP_VERSION: 7.3
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    - STORAGE: scality
+#      STORAGE_CONFIG_SUFFIX: .multibucket
+#      PHP_VERSION: 7.3
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit-scality
+#      NEED_CORE: true
+#      NEED_INSTALL_APP: true
+#      OWNCLOUD_LOG: true
+#
+#    # acceptance tests
+#    # UI master
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 1
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 2
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 3
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 4
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 5
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 6
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 7
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 8
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 9
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 10
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 11
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 12
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 13
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 14
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 15
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 16
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 17
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 18
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 19
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-web-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 20
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    # API master
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 1
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 2
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 3
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 4
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 5
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 6
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 7
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 8
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 9
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 10
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 11
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 12
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 13
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      PREPARE_ACCEPTANCE: true
+#      NEED_SERVER: true
+#      USE_FEDERATED_SERVER: true
+#      FEDERATION_OC_VERSION: daily-master-qa
+#      TEST_SUITE: core-api-acceptance
+#      DB_TYPE: mysql
+#      DB_HOST: mysql
+#      STORAGE: ceph
+#      OWNCLOUD_LOG: true
+#      PART: 14
+#      NEED_CORE: true
+#      NEED_INSTALL_BUILT_APP: true
+#
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
       PREPARE_ACCEPTANCE: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,6 @@ workspace:
   base: /drone
   path: files_primary_s3
 
-
 branches: [ master, release, release/* ]
 
 pipeline:
@@ -226,7 +225,7 @@ pipeline:
       - . /drone/saved-settings.sh
       - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
       - chmod +x /drone/server/tests/acceptance/run.sh
-      - make test-acceptance-api
+      - make test-acceptance-api ACCEPTANCE_RUNNER=/drone/server/tests/acceptance/run.sh
     when:
       matrix:
         TEST_SUITE: core-api-acceptance
@@ -250,7 +249,7 @@ pipeline:
       - . /drone/saved-settings.sh
       - chmod 777 /drone/server/tests/acceptance/filesForUpload -R
       - chmod +x /drone/server/tests/acceptance/run.sh
-      - make test-acceptance-webui
+      - make test-acceptance-webui ACCEPTANCE_RUNNER=/drone/server/tests/acceptance/run.sh
     when:
       matrix:
         TEST_SUITE: core-web-acceptance

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,8 @@ $config
 	->exclude('.composer')
 	->exclude('vendor-bin')
 	->notPath('/^c3.php/')
+	->notPath('/^scoper.inc.php/')
+	->notPath('/^scoper-fix-autoloader.php/')
     ->in(__DIR__);
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
 PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 PHPSCOPER=php vendor-bin/php-scoper/vendor/bin/php-scoper
 BEHAT_BIN=vendor-bin/behat/vendor/bin/behat
+ACCEPTANCE_RUNNER?=../../tests/acceptance/run.sh
 
 # start with displaying help
 help: ## Show this help message
@@ -133,17 +134,17 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 .PHONY: test-acceptance-api
 test-acceptance-api: ## Run API acceptance tests
 test-acceptance-api: $(acceptance_test_deps)
-	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type api
+	BEHAT_BIN=$(BEHAT_BIN) $(ACCEPTANCE_RUNNER) --remote --type api
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli: ## Run CLI acceptance tests
 test-acceptance-cli: $(acceptance_test_deps)
-	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type cli
+	BEHAT_BIN=$(BEHAT_BIN) $(ACCEPTANCE_RUNNER) --remote --type cli
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui: ## Run webUI acceptance tests
 test-acceptance-webui: $(acceptance_test_deps)
-	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type webUI
+	BEHAT_BIN=$(BEHAT_BIN) $(ACCEPTANCE_RUNNER) --remote --type webUI
 
 #
 # Dependency management

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ scope: vendor-bin/php-scoper/vendor
 	mkdir -p $(scoper_directory)
 	$(PHPSCOPER) add-prefix --output-dir $(scoper_directory) --force --config=./scoper.inc.php
 	$(COMPOSER_BIN) dump-autoload --working-dir $(scoper_directory) --classmap-authoritative
+	php scoper-fix-autoloader.php
 
 # Builds the package for the app store, ignores php and js tests
 .PHONY: appstore

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,16 @@ clean: ## Remove appstore build
 dist: ## Builds the appstore package
 	make appstore
 
+.PHONY: dist-qa
+dist-qa: ## Builds the qa package
+dist-qa: vendor scope
+	rm -rf $(appstore_build_directory)
+	mkdir -p $(appstore_package_name)
+	cp --parents -r appinfo LICENSE CHANGELOG.md tests $(appstore_package_name)
+	cp -r $(scoper_directory)/lib $(appstore_package_name)/lib
+	cp -r $(scoper_directory)/vendor $(appstore_package_name)/vendor
+	tar --format=gnu -czf $(appstore_package_name).tar.gz -C $(appstore_package_name)/../ $(app_name)
+
 .PHONY: scope
 scope: ## Scoper
 scope: vendor-bin/php-scoper/vendor

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,8 @@
   "description": "ownCloud primary storage integration using S3 protocol",
   "require": {
     "dg/composer-cleaner": "^2.0",
-    "aws/aws-sdk-php": "^3.48"
-  },
-  "replace": {
-    "guzzlehttp/guzzle": "*"
+    "aws/aws-sdk-php": "^3.48",
+    "guzzlehttp/guzzle": "^5.3"
   },
   "license": "GPL-2.0",
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97ab09c2371af19695e87102e3323426",
+    "content-hash": "342fdcf6fc4b95e2996daed635146dbb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.109.2",
+            "version": "3.109.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "bfbf0f0f1e4949747bd3e77dd8de94af47f7fb72"
+                "reference": "e8d3416f9b1e21029fc0eb63df075e325c690187"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/bfbf0f0f1e4949747bd3e77dd8de94af47f7fb72",
-                "reference": "bfbf0f0f1e4949747bd3e77dd8de94af47f7fb72",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e8d3416f9b1e21029fc0eb63df075e325c690187",
+                "reference": "e8d3416f9b1e21029fc0eb63df075e325c690187",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-08-12T18:14:30+00:00"
+            "time": "2019-08-19T18:08:45+00:00"
         },
         {
             "name": "dg/composer-cleaner",
@@ -134,6 +134,59 @@
                 "composer"
             ],
             "time": "2019-02-05T21:18:31+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/93bbdb30d59be6cd9839495306c65f2907370eb9",
+                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0",
+                "react/promise": "^2.2"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-07-31T13:33:10+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -256,6 +309,107 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2018-07-31T13:22:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -401,6 +555,52 @@
             ],
             "description": "A polyfill for getallheaders.",
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2019-01-07T21:25:54+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/s3storage.php
+++ b/lib/s3storage.php
@@ -61,7 +61,6 @@ class S3Storage implements IObjectStore, IVersionedObjectStorage {
 		if (!isset($params['options']) || !isset($params['bucket'])) {
 			throw new \Exception('Connection options and bucket must be configured.');
 		}
-
 		$this->params = $params;
 	}
 

--- a/scoper-fix-autoloader.php
+++ b/scoper-fix-autoloader.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This helper is needed to "trick" composer autoloader to load the prefixed files
+ * Otherwise if owncloud/core contains the same libraries ( i.e. guzzle ) it won't
+ * load the files, as the file hash is the same and thus composer would think this was already loaded
+ *
+ * More information also found here: https://github.com/humbug/php-scoper/issues/298
+ */
+
+$scoper_path = './build/scoper/vendor/composer';
+
+
+$static_loader_path = $scoper_path.'/autoload_static.php';
+echo "Fixing $static_loader_path \n";
+$static_loader = file_get_contents($static_loader_path);
+$static_loader = \preg_replace('/\'([A-Za-z0-9]*?)\' => __DIR__ \. (.*?),/', '\'a$1\' => __DIR__ . $2,', $static_loader);
+file_put_contents($static_loader_path, $static_loader);
+
+
+$files_loader_path = $scoper_path.'/autoload_files.php';
+echo "Fixing $files_loader_path \n";
+$files_loader = file_get_contents($files_loader_path);
+$files_loader = \preg_replace('/\'(.*?)\' => (.*?),/', '\'a$1\' => $2,', $files_loader);
+file_put_contents($files_loader_path, $files_loader);

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -52,6 +52,14 @@ return [
             }
             return \preg_replace('/namespace '.$prefix.'\\\\(.*)/', 'namespace $1', $content);
         },
+        // This should address gmdate constant being scoped in aws signature
+        // also see https://github.com/humbug/php-scoper/issues/301
+        function (string $filePath, string $prefix, string $content): string {
+            if (false === (\strpos($filePath, 'vendor/aws/aws-sdk-php/src/Signature/SignatureV4.php'))) {
+                return $content;
+            }
+            return \preg_replace('/const ISO8601_BASIC = \'(.*)\';/', '    const ISO8601_BASIC = \'Ymd\THis\Z\';', $content);
+        },
 
     // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
     // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -60,6 +60,15 @@ return [
             }
             return \preg_replace('/const ISO8601_BASIC = \'(.*)\';/', '    const ISO8601_BASIC = \'Ymd\THis\Z\';', $content);
         },
+        // Fix AWS Exception magic
+        function (string $filePath, string $prefix, string $content): string {
+            if (false === (\strpos($filePath, 'vendor/aws/aws-sdk-php/src/AwsClient.php'))) {
+                return $content;
+            }
+            $content = \preg_replace('/Aws\\\\\\\\\{\$service\}\\\\\\\\Exception\\\\\\\\\{\$service\}Exception/', $prefix.'\\\\\\\\Aws\\\\\\\\{$service}\\\\\\\\Exception\\\\\\\\{$service}Exception', $content);
+            return $content;
+        }
+    ],
 
     // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
     // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -60,6 +60,20 @@ return [
             }
             return \preg_replace('/const ISO8601_BASIC = \'(.*)\';/', '    const ISO8601_BASIC = \'Ymd\THis\Z\';', $content);
         },
+        // Needed to address https://github.com/humbug/php-scoper/issues/298
+        function (string $filePath, string $prefix, string $content): string {
+            if (false === (\strpos($filePath, 'autoload_files.php'))) {
+                return $content;
+            }
+            return \preg_replace('/\'(.*?)\' => (.*?),', '\'a$1\' => $2,', $content);
+        },
+        // Needed to address https://github.com/humbug/php-scoper/issues/298
+        function (string $filePath, string $prefix, string $content): string {
+            if (false === (\strpos($filePath, 'autoload_static.php'))) {
+                return $content;
+            }
+            return \preg_replace('/\'(.*?)\' => __DIR__ \. (.*?),/', '\'a$1\' => __DIR__ . $2,', $content);
+        },
         // Fix AWS Exception magic
         function (string $filePath, string $prefix, string $content): string {
             if (false === (\strpos($filePath, 'vendor/aws/aws-sdk-php/src/AwsClient.php'))) {

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    // The prefix configuration. If a non null value will be used, a random prefix will be generated.
+    'prefix' => null,
+
+    // By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
+    // directory. You can however define which files should be scoped by defining a collection of Finders in the
+    // following configuration key.
+    //
+    // For more see: https://github.com/humbug/php-scoper#finders-and-paths
+    'finders' => [
+        Finder::create()->files()->in('lib'),
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+            ->exclude([
+                'doc',
+                'test',
+                'test_old',
+                'tests',
+                'Tests',
+                'vendor-bin',
+            ])
+            ->in('vendor'),
+        Finder::create()->append([
+            'composer.json',
+        ]),
+    ],
+
+    // Whitelists a list of files. Unlike the other whitelist related features, this one is about completely leaving
+    // a file untouched.
+    // Paths are relative to the configuration file unless if they are already absolute
+    'files-whitelist' => [],
+
+    // When scoping PHP files, there will be scenarios where some of the code being scoped indirectly references the
+    // original namespace. These will include, for example, strings or string manipulations. PHP-Scoper has limited
+    // support for prefixing such strings. To circumvent that, you can define patchers to manipulate the file to your
+    // heart contents.
+    //
+    // For more see: https://github.com/humbug/php-scoper#patchers
+    'patchers' => [],
+
+    // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
+    // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if
+    // you have a PHPUnit PHAR with isolated code, you still want the PHAR to be able to understand the
+    // PHPUnit\Framework\TestCase class.
+    //
+    // A way to achieve this is by specifying a list of classes to not prefix with the following configuration key. Note
+    // that this does not work with functions or constants neither with classes belonging to the global namespace.
+    //
+    // Fore more see https://github.com/humbug/php-scoper#whitelist
+    'whitelist' => [
+        'OCP\*',
+        'OC\*',
+        'OCA\*',
+        'Symfony\Component\Console\*',
+        'OCA\Files_Primary_S3'
+    ],
+
+    // If `true` then the user defined constants belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-constants' => true,
+
+    // If `true` then the user defined classes belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-classes' => true,
+
+    // If `true` then the user defined functions belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-functions' => true,
+];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -44,7 +44,14 @@ return [
     // heart contents.
     //
     // For more see: https://github.com/humbug/php-scoper#patchers
-    'patchers' => [],
+    'patchers' => [
+        // The patcher ensures that files belonging to the app will not be prefixed
+        function (string $filePath, string $prefix, string $content): string {
+            if (false === (\strpos($filePath, 'files_primary_s3/lib'))) {
+                return $content;
+            }
+            return \preg_replace('/namespace '.$prefix.'\\\\(.*)/', 'namespace $1', $content);
+        },
 
     // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
     // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
+
+
 return [
     // The prefix configuration. If a non null value will be used, a random prefix will be generated.
     'prefix' => null,
@@ -59,20 +61,6 @@ return [
                 return $content;
             }
             return \preg_replace('/const ISO8601_BASIC = \'(.*)\';/', '    const ISO8601_BASIC = \'Ymd\THis\Z\';', $content);
-        },
-        // Needed to address https://github.com/humbug/php-scoper/issues/298
-        function (string $filePath, string $prefix, string $content): string {
-            if (false === (\strpos($filePath, 'autoload_files.php'))) {
-                return $content;
-            }
-            return \preg_replace('/\'(.*?)\' => (.*?),', '\'a$1\' => $2,', $content);
-        },
-        // Needed to address https://github.com/humbug/php-scoper/issues/298
-        function (string $filePath, string $prefix, string $content): string {
-            if (false === (\strpos($filePath, 'autoload_static.php'))) {
-                return $content;
-            }
-            return \preg_replace('/\'(.*?)\' => __DIR__ \. (.*?),/', '\'a$1\' => __DIR__ . $2,', $content);
         },
         // Fix AWS Exception magic
         function (string $filePath, string $prefix, string $content): string {

--- a/vendor-bin/php-scoper/composer.json
+++ b/vendor-bin/php-scoper/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "humbug/php-scoper": "^0.12.4"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}


### PR DESCRIPTION
This pullrequest tries to accomplish similar aspects as #142 - but utilizes humbug/scoper https://github.com/humbug/php-scoper

Currently scoping requires a 3 step process:

1) run php-scoper with the provided configuration file
2) dumpe the autoloader for the scoped files
3) fix the composer autoloader for loading static ( scoped files ) `scoper-fix-autoloader.php`

As this process touches composer and autoloading - the scoping can only happen in the build process of the artifact.

Thus the 3 steps have been included in the Makefile in two targets:
- `make dist`
- `make dist-qa`

For 🤖 - this also means, that now not the source code as it exists in the working space should/needs to be tested. This time we need to install the artifact and then perform our tests on top.

As the unit-tests are normally not included in an artifact - the `dist-qa` target was thus created.
So bot acceptance and unit tests are performed on top of the scoped files.

The drone.yml has been adjusted to reflect this behaviour - with the migration to drone 1.0 and starlark this probably needs to be migrated to the new format.
For this app ( and any other app that might use scoped dependencies ) it is of key essence, to test the final artifact, as the source code and the vendor files are touched during the scoping process.
For development this should not make any difference.

### Important things noticed

- **AWS SDK**
The AWS Library had issue being fully scoped initially, and thus it was needed to write [patchers](https://github.com/humbug/php-scoper#patchers) for humbug
  - A patcher for reversing the issue of a gmdate string being changed https://github.com/owncloud/files_primary_s3/pull/237/commits/7c76e639babf7a7233b41d009e2b632057304e9c 
  - A patcher for fixing the exception handling of the AWS SDK - as these are infered by the service name indirectly https://github.com/owncloud/files_primary_s3/pull/237/commits/f2b144a75728d8958c9b66e0339f12a19d9cdf90

- **GUZZLE SDK**
  In order to correctly use guzzle with scoping - it was better to put the guzzle sdk to the vendor libraries and get them scoped, as all references in other required libraries would have otherwise been scoped or needed to be whitelisted. Additionally this now makes files_primary_s3 app independent from the core guzzle version used - as it has its own scoped version

  In the guzzle SDK, there is a file called `functions.php` - loading these plain files in composer is based on a package+filename. These loaded files are registered globally and only loaded once for every package. 
  As Scoper does not change the packagename, the `functions.php` from guzzle wouldn't be loaded - hence it was necessary to write a "fixer" for the dumped composer autoloader, to tell composer that the `functions.php` referenced in this app is actually a different one compared to the one already loaded from any ohter app/core


Below some of the quirks were described in single posts - and some of the solutions as well