### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -742,6 +742,7 @@ def acceptance():
 		'filterTags': '',
 		'logLevel': '2',
 		'emailNeeded': False,
+		'ldapNeeded': False,
 		'cephS3': False,
 		'scalityS3': False,
 		'extraSetup': [],
@@ -848,6 +849,9 @@ def acceptance():
 								if params['emailNeeded']:
 									environment['MAILHOG_HOST'] = 'email'
 
+								if params['ldapNeeded']:
+									environment['TEST_EXTERNAL_USER_BACKENDS'] = True
+
 								if (needObjectStore):
 									environment['OC_TEST_ON_OBJECTSTORE'] = '1'
 									if (params['cephS3'] != False):
@@ -917,6 +921,7 @@ def acceptance():
 										databaseService(db) +
 										browserService(browser) +
 										emailService(params['emailNeeded']) +
+										ldapService(params['ldapNeeded']) +
 										cephService(params['cephS3']) +
 										scalityService(params['scalityS3']) +
 										params['extraServices'] +
@@ -966,6 +971,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}
@@ -1047,6 +1056,23 @@ def emailService(emailNeeded):
 			'name': 'email',
 			'image': 'mailhog/mailhog',
 			'pull': 'always',
+		}]
+
+	return []
+
+def ldapService(ldapNeeded):
+	if ldapNeeded:
+		return [{
+			'name': 'ldap',
+			'image': 'osixia/openldap',
+			'pull': 'always',
+			'environment': {
+				'LDAP_DOMAIN': 'owncloud.com',
+				'LDAP_ORGANISATION': 'owncloud',
+				'LDAP_ADMIN_PASSWORD': 'admin',
+				'LDAP_TLS_VERIFY_CLIENT': 'never',
+				'HOSTNAME': 'ldap',
+			}
 		}]
 
 	return []
@@ -1265,7 +1291,6 @@ def setupCeph(cephS3):
 		]
 	}]
 
-
 def setupScality(scalityS3):
 	if type(scalityS3) == "bool":
 		if scalityS3:
@@ -1292,7 +1317,6 @@ def setupScality(scalityS3):
 			'for I in $(seq 1 9); do php ./occ s3:create-bucket  owncloud$I --accept-warning; done',
 		] if createExtraBuckets else [])
 	}]
-
 
 def fixPermissions(phpVersion, federatedServerNeeded):
 	return [{

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -755,6 +755,7 @@ def acceptance():
 		'runAllSuites': False,
 		'runCoreTests': False,
 		'numberOfParts': 1,
+		'cron': '',
 	}
 
 	if 'defaults' in config:
@@ -928,16 +929,18 @@ def acceptance():
 										owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False) +
 										(owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if params['federatedServerNeeded'] else []),
 									'depends_on': [],
-									'trigger': {
-										'ref': [
-											'refs/pull/**',
-											'refs/tags/**'
-										]
-									}
+									'trigger': {}
 								}
 
-								for branch in config['branches']:
-									result['trigger']['ref'].append('refs/heads/%s' % branch)
+								if (params['cron'] == ''):
+									result['trigger']['ref'] = [
+										'refs/pull/**',
+										'refs/tags/**'
+									]
+									for branch in config['branches']:
+										result['trigger']['ref'].append('refs/heads/%s' % branch)
+								else:
+									result['trigger']['cron'] = params['cron']
 
 								pipelines.append(result)
 
@@ -1077,37 +1080,49 @@ def ldapService(ldapNeeded):
 
 	return []
 
-def scalityService(scalityS3):
-	if not scalityS3:
-		return []
+def scalityService(serviceParams):
+	serviceEnvironment = {
+		'HOST_NAME': 'scality'
+	}
+
+	if type(serviceParams) == "bool":
+		if not serviceParams:
+			return []
+	else:
+		if 'extraEnvironment' in serviceParams:
+			for env in serviceParams['extraEnvironment']:
+				serviceEnvironment[env] = serviceParams['extraEnvironment'][env]
 
 	return [{
 		'name': 'scality',
 		'image': 'owncloudci/scality-s3server',
 		'pull': 'always',
-		'environment': {
-			'HOST_NAME': 'scality'
-		}
+		'environment': serviceEnvironment
 	}]
 
+def cephService(serviceParams):
+	serviceEnvironment = {
+		'NETWORK_AUTO_DETECT': '4',
+		'RGW_NAME': 'ceph',
+		'CEPH_DEMO_UID': 'owncloud',
+		'CEPH_DEMO_ACCESS_KEY': 'owncloud123456',
+		'CEPH_DEMO_SECRET_KEY': 'secret123456',
+	}
 
-def cephService(cephS3):
-	if not cephS3:
-		return []
+	if type(serviceParams) == "bool":
+		if not serviceParams:
+			return []
+	else:
+		if 'extraEnvironment' in serviceParams:
+			for env in serviceParams['extraEnvironment']:
+				serviceEnvironment[env] = serviceParams['extraEnvironment'][env]
 
 	return [{
 		'name': 'ceph',
 		'image': 'owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04',
 		'pull': 'always',
-		'environment': {
-			'NETWORK_AUTO_DETECT': '4',
-			'RGW_NAME': 'ceph',
-			'CEPH_DEMO_UID': 'owncloud',
-			'CEPH_DEMO_ACCESS_KEY': 'owncloud123456',
-			'CEPH_DEMO_SECRET_KEY': 'secret123456',
-		}
+		'environment': serviceEnvironment
 	}]
-
 
 def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncloud/server', ssl = True):
 	if ssl:
@@ -1274,9 +1289,15 @@ def setupServerAndApp(phpVersion, logLevel):
 		]
 	}]
 
-def setupCeph(cephS3):
-	if not cephS3:
-		return []
+def setupCeph(serviceParams):
+	if type(serviceParams) == "bool":
+		if serviceParams:
+			# specify an empty dict that will get the defaults
+			serviceParams = {}
+		else:
+			return []
+
+	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 
 	return [{
 		'name': 'setup-ceph',
@@ -1287,21 +1308,23 @@ def setupCeph(cephS3):
 			'cd /var/www/owncloud/server/apps/files_primary_s3',
 			'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 			'cd /var/www/owncloud/server',
+		] + ([
 			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
-		]
+		] if createFirstBucket else [])
 	}]
 
-def setupScality(scalityS3):
-	if type(scalityS3) == "bool":
-		if scalityS3:
+def setupScality(serviceParams):
+	if type(serviceParams) == "bool":
+		if serviceParams:
 			# specify an empty dict that will get the defaults
-			scalityS3 = {}
+			serviceParams = {}
 		else:
 			return []
 
-	specialConfig = '.' + scalityS3['config'] if 'config' in scalityS3 else ''
+	specialConfig = '.' + serviceParams['config'] if 'config' in serviceParams else ''
 	configFile = 'scality%s.config.php' % specialConfig
-	createExtraBuckets = scalityS3['createExtraBuckets'] if 'createExtraBuckets' in scalityS3 else False
+	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
+	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 
 	return [{
 		'name': 'setup-scality',
@@ -1311,9 +1334,10 @@ def setupScality(scalityS3):
 			'wait-for-it -t 60 scality:8000',
 			'cd /var/www/owncloud/server/apps/files_primary_s3',
 			'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
-			'cd /var/www/owncloud/server',
-			'php occ s3:create-bucket owncloud --accept-warning'
+			'cd /var/www/owncloud/server'
 		] + ([
+			'php occ s3:create-bucket owncloud --accept-warning'
+		] if createFirstBucket else []) + ([
 			'for I in $(seq 1 9); do php ./occ s3:create-bucket  owncloud$I --accept-warning; done',
 		] if createExtraBuckets else [])
 	}]

--- a/.drone.yml
+++ b/.drone.yml
@@ -10398,6 +10398,9 @@ trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-scality-php7.0-sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
-vendor
+/build/
+/l10n/.transifexrc
 .php_cs.cache
+
+# Composer
+vendor/
+vendor-bin/**/vendor
+vendor-bin/**/composer.lock
+
+# Mac OS
+.DS_Store
+
+# Tests - auto-generated files
+/tests/acceptance/output*
+/tests/output
+
 composer
 .composer
 .npm
-build
-


### PR DESCRIPTION
Like https://github.com/owncloud/activity/pull/794

If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.