### PR TITLE
[WIP] Ensure different users end up in different buckets

### DIFF
--- a/tests/simplemapperensuredmultibucket.php
+++ b/tests/simplemapperensuredmultibucket.php
@@ -1,0 +1,43 @@
+<?php
+namespace OCA\Files_Primary_S3\Tests;
+
+use OCP\IUser;
+
+/**
+ * Class Mapper
+ * NOTE: This class is only intended for testing. It doesn't have any persistence,
+ * so the same user might end up in different buckets if you can't ensure the same
+ * order in all the requests
+ *
+ * @package OC\Files\ObjectStore
+ *
+ * Map a user to a bucket.
+ */
+class SimpleMapperEnsuredMultibucket {
+	private static $knownUserList = [];
+	/** @var IUser */
+	private $user;
+
+	/**
+	 * Mapper constructor.
+	 *
+	 * @param IUser $user
+	 */
+	public function __construct(IUser $user) {
+		$this->user = $user;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBucket() {
+		$uid = $this->user->getUID();
+		$searchIndex = \array_search($uid, self::$knownUserList, true);
+		if ($searchIndex === false) {
+			// missing uid -> add it to the list
+			self::$knownUserList[] = $uid;
+			$searchIndex = \count(self::$knownUserList) - 1;
+		}
+		return (string)(($searchIndex % 10) + 1);
+	}
+}


### PR DESCRIPTION
This should fix the instability of the tests.

I think we should use a new mapper for this. The reason is that this class is made only for the unittests, and it expected to have problems during normal usage due to the lack of persistence. The `SimpleMapper`, on the other hand, can be used normally. I think it make sense to keep both mappers.

@phil-davis Could you take over from here? I'm not fully sure how this is wired up in drone. I guess we'll need a new configuration in order to use this class to be injected in drone.
Note that the bucket range for the mapper is 1-10 (both included), in case we need to change a bit the class (there is a "create-bucket.sh" script to create the buckets from 1-10, but the drone.yml file has some commands to create the buckets from 1-9)