### PR TITLE
Drop PHP 7.0 from drone CI

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -22,7 +22,6 @@ config = {
 	'phpunit': {
 		'scality': {
 			'phpVersions': [
-				'7.0',
 				'7.1',
 				'7.2',
 				'7.3',
@@ -38,7 +37,6 @@ config = {
 		},
 		'scality-multibucket': {
 			'phpVersions': [
-				'7.0',
 				'7.1',
 				'7.2',
 				'7.3',
@@ -55,7 +53,6 @@ config = {
 		},
 		'ceph': {
 			'phpVersions': [
-				'7.0',
 				'7.1',
 				'7.2',
 				'7.3',
@@ -170,7 +167,7 @@ def codestyle():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 	}
 
 	if 'defaults' in config:
@@ -359,7 +356,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 	}
 
 	if 'defaults' in config:
@@ -431,7 +428,7 @@ def build():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'commands': [
 			'make dist'
 		],
@@ -556,13 +553,13 @@ def javascript():
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.0') +
-			setupServerAndApp('7.0', params['logLevel']) +
+			installApp('7.1') +
+			setupServerAndApp('7.1', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.0',
+				'image': 'owncloudci/php:7.1',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [
@@ -609,7 +606,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
@@ -776,7 +773,7 @@ def acceptance():
 	default = {
 		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
@@ -1361,7 +1358,7 @@ def setupCeph(serviceParams):
 
 	return [{
 		'name': 'setup-ceph',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
@@ -1389,7 +1386,7 @@ def setupScality(serviceParams):
 
 	return [{
 		'name': 'setup-scality',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'php occ s3:create-bucket owncloud --accept-warning'

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: coding-standard-php7.0
+name: coding-standard-php7.1
 
 platform:
   os: linux
@@ -14,7 +14,7 @@ workspace:
 steps:
 - name: coding-standard
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - make test-php-style
 
@@ -75,45 +75,6 @@ steps:
   image: owncloudci/php:7.2
   commands:
   - make test-php-phpstan
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
-name: phan-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/files_primary_s3
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/files_primary_s3
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-phan
 
 trigger:
   ref:
@@ -241,90 +202,6 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: phpunit-scality-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/files_primary_s3
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/files_primary_s3
-    version: daily-master-qa
-
-- name: install-app-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - composer install
-
-- name: setup-server-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e files_primary_s3
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: setup-scality
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - wait-for-it -t 120 scality:8000
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - cp tests/drone/scality.config.php /var/www/owncloud/server/config
-  - cd /var/www/owncloud/server
-  - php occ s3:create-bucket owncloud --accept-warning
-  - for I in $(seq 1 9); do php ./occ s3:create-bucket  owncloud$I --accept-warning; done
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-services:
-- name: scality
-  pull: always
-  image: owncloudci/scality-s3server
-  environment:
-    HOST_NAME: scality
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phpstan-php7.2
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
 name: phpunit-scality-php7.1-sqlite
 
 platform:
@@ -370,7 +247,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -399,9 +276,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -454,7 +330,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -483,9 +359,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -538,7 +413,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -567,93 +442,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-scality-multibucket-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/files_primary_s3
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/files_primary_s3
-    version: daily-master-qa
-
-- name: install-app-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - composer install
-
-- name: setup-server-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e files_primary_s3
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: setup-scality
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - wait-for-it -t 120 scality:8000
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - cp tests/drone/scality.multibucket.config.php /var/www/owncloud/server/config
-  - cd /var/www/owncloud/server
-  - php occ s3:create-bucket owncloud --accept-warning
-  - for I in $(seq 1 9); do php ./occ s3:create-bucket  owncloud$I --accept-warning; done
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-services:
-- name: scality
-  pull: always
-  image: owncloudci/scality-s3server
-  environment:
-    HOST_NAME: scality
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -706,7 +496,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -735,9 +525,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -790,7 +579,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -819,9 +608,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -874,7 +662,7 @@ steps:
 
 - name: setup-scality
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -903,96 +691,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-ceph-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/files_primary_s3
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/files_primary_s3
-    version: daily-master-qa
-
-- name: install-app-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - composer install
-
-- name: setup-server-files_primary_s3
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e files_primary_s3
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: setup-ceph
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - wait-for-it -t 120 ceph:80
-  - cd /var/www/owncloud/server/apps/files_primary_s3
-  - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
-  - cd /var/www/owncloud/server
-  - ./apps/files_primary_s3/tests/drone/create-bucket.sh
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-services:
-- name: ceph
-  pull: always
-  image: owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04
-  environment:
-    CEPH_DEMO_ACCESS_KEY: owncloud123456
-    CEPH_DEMO_SECRET_KEY: secret123456
-    CEPH_DEMO_UID: owncloud
-    NETWORK_AUTO_DETECT: 4
-    RGW_NAME: ceph
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1045,7 +745,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1077,9 +777,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1132,7 +831,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1164,9 +863,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1219,7 +917,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1251,9 +949,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1261,7 +958,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-1-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-1-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1287,7 +984,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1305,7 +1002,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -1325,14 +1022,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1351,7 +1048,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1361,14 +1058,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1417,7 +1114,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1429,7 +1126,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1446,9 +1143,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1456,7 +1152,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-2-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-2-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1482,7 +1178,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1500,7 +1196,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -1520,14 +1216,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1546,7 +1242,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1556,14 +1252,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1612,7 +1308,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1624,7 +1320,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1641,9 +1337,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1651,7 +1346,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-3-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-3-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1677,7 +1372,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1695,7 +1390,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -1715,14 +1410,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1741,7 +1436,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1751,14 +1446,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1807,7 +1502,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1819,7 +1514,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1836,9 +1531,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1846,7 +1540,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-4-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-4-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1872,7 +1566,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1890,7 +1584,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -1910,14 +1604,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1936,7 +1630,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -1946,14 +1640,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2002,7 +1696,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2014,7 +1708,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2031,9 +1725,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2041,7 +1734,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-5-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-5-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2067,7 +1760,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2085,7 +1778,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2105,14 +1798,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2131,7 +1824,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -2141,14 +1834,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2197,7 +1890,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2209,7 +1902,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2226,9 +1919,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2236,7 +1928,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-6-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-6-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2262,7 +1954,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2280,7 +1972,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2300,14 +1992,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2326,7 +2018,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -2336,14 +2028,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2392,7 +2084,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2404,7 +2096,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2421,9 +2113,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2431,7 +2122,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-7-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-7-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2457,7 +2148,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2475,7 +2166,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2495,14 +2186,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2521,7 +2212,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -2531,14 +2222,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2587,7 +2278,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2599,7 +2290,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2616,9 +2307,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2626,7 +2316,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-8-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-8-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2652,7 +2342,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2670,7 +2360,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2690,14 +2380,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2716,7 +2406,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -2726,14 +2416,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2782,7 +2472,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2794,7 +2484,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2811,9 +2501,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2821,7 +2510,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-9-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-9-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2847,7 +2536,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2865,7 +2554,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2885,14 +2574,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2911,7 +2600,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -2921,14 +2610,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2977,7 +2666,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2989,7 +2678,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3006,9 +2695,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3016,7 +2704,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-10-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-10-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3042,7 +2730,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3060,7 +2748,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3080,14 +2768,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3106,7 +2794,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -3116,14 +2804,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3172,7 +2860,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3184,7 +2872,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3201,9 +2889,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3211,7 +2898,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-11-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-11-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3237,7 +2924,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3255,7 +2942,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3275,14 +2962,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3301,7 +2988,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -3311,14 +2998,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3367,7 +3054,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3379,7 +3066,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3396,9 +3083,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3406,7 +3092,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-12-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-12-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3432,7 +3118,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3450,7 +3136,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3470,14 +3156,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3496,7 +3182,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -3506,14 +3192,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3562,7 +3248,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3574,7 +3260,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3591,9 +3277,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3601,7 +3286,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-13-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-13-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3627,7 +3312,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3645,7 +3330,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3665,14 +3350,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3691,7 +3376,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -3701,14 +3386,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3757,7 +3442,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3769,7 +3454,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3786,9 +3471,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3796,7 +3480,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-14-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-14-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3822,7 +3506,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3840,7 +3524,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3860,14 +3544,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3886,7 +3570,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -3896,14 +3580,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3952,7 +3636,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3964,7 +3648,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3981,9 +3665,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3991,7 +3674,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-15-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-15-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4017,7 +3700,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4035,7 +3718,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4055,14 +3738,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4081,7 +3764,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -4091,14 +3774,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4147,7 +3830,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4159,7 +3842,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4176,9 +3859,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4186,7 +3868,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-16-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-16-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4212,7 +3894,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4230,7 +3912,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4250,14 +3932,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4276,7 +3958,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -4286,14 +3968,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4342,7 +4024,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4354,7 +4036,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4371,9 +4053,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4381,7 +4062,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-17-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-17-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4407,7 +4088,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4425,7 +4106,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4445,14 +4126,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4471,7 +4152,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -4481,14 +4162,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4537,7 +4218,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4549,7 +4230,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4566,9 +4247,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4576,7 +4256,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-18-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-18-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4602,7 +4282,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4620,7 +4300,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4640,14 +4320,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4666,7 +4346,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -4676,14 +4356,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4732,7 +4412,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4744,7 +4424,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4761,9 +4441,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4771,7 +4450,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-19-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-19-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4797,7 +4476,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4815,7 +4494,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4835,14 +4514,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4861,7 +4540,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -4871,14 +4550,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4927,7 +4606,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4939,7 +4618,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4956,9 +4635,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4966,7 +4644,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-20-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-20-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4992,7 +4670,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5010,7 +4688,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5030,14 +4708,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5056,7 +4734,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -5066,14 +4744,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5122,7 +4800,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5134,7 +4812,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5151,9 +4829,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5161,7 +4838,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-21-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-21-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5187,7 +4864,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5205,7 +4882,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5225,14 +4902,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5251,7 +4928,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -5261,14 +4938,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5317,7 +4994,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5329,7 +5006,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5346,9 +5023,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5356,7 +5032,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-22-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-22-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5382,7 +5058,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5400,7 +5076,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5420,14 +5096,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5446,7 +5122,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -5456,14 +5132,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5512,7 +5188,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5524,7 +5200,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5541,9 +5217,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5551,7 +5226,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-23-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-23-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5577,7 +5252,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5595,7 +5270,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5615,14 +5290,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5641,7 +5316,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -5651,14 +5326,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5707,7 +5382,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5719,7 +5394,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5736,9 +5411,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5746,7 +5420,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-24-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-24-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5772,7 +5446,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5790,7 +5464,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5810,14 +5484,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5836,7 +5510,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -5846,14 +5520,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5902,7 +5576,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5914,7 +5588,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5931,9 +5605,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5941,7 +5614,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-25-master-chrome-mariadb10.2-php7.0
+name: webUIall-25-25-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5967,7 +5640,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5985,7 +5658,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6005,14 +5678,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6031,7 +5704,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -6041,14 +5714,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6097,7 +5770,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6109,7 +5782,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6126,9 +5799,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6136,7 +5808,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-1-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-1-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6162,7 +5834,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6180,7 +5852,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6200,14 +5872,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6226,7 +5898,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -6236,14 +5908,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6292,7 +5964,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6304,7 +5976,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6319,9 +5991,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6329,7 +6000,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-2-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-2-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6355,7 +6026,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6373,7 +6044,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6393,14 +6064,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6419,7 +6090,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -6429,14 +6100,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6485,7 +6156,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6497,7 +6168,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6512,9 +6183,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6522,7 +6192,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-3-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-3-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6548,7 +6218,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6566,7 +6236,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6586,14 +6256,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6612,7 +6282,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -6622,14 +6292,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6678,7 +6348,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6690,7 +6360,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6705,9 +6375,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6715,7 +6384,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-4-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-4-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6741,7 +6410,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6759,7 +6428,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6779,14 +6448,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6805,7 +6474,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -6815,14 +6484,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6871,7 +6540,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6883,7 +6552,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6898,9 +6567,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6908,7 +6576,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-5-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-5-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6934,7 +6602,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6952,7 +6620,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6972,14 +6640,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6998,7 +6666,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7008,14 +6676,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7064,7 +6732,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7076,7 +6744,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7091,9 +6759,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7101,7 +6768,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-6-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-6-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7127,7 +6794,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7145,7 +6812,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7165,14 +6832,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7191,7 +6858,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7201,14 +6868,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7257,7 +6924,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7269,7 +6936,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7284,9 +6951,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7294,7 +6960,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-7-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-7-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7320,7 +6986,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7338,7 +7004,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7358,14 +7024,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7384,7 +7050,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7394,14 +7060,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7450,7 +7116,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7462,7 +7128,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7477,9 +7143,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7487,7 +7152,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-8-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-8-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7513,7 +7178,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7531,7 +7196,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7551,14 +7216,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7577,7 +7242,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7587,14 +7252,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7643,7 +7308,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7655,7 +7320,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7670,9 +7335,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7680,7 +7344,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-9-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-9-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7706,7 +7370,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7724,7 +7388,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7744,14 +7408,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7770,7 +7434,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7780,14 +7444,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7836,7 +7500,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7848,7 +7512,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7863,9 +7527,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7873,7 +7536,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-10-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-10-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7899,7 +7562,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7917,7 +7580,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7937,14 +7600,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7963,7 +7626,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -7973,14 +7636,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8029,7 +7692,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8041,7 +7704,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8056,9 +7719,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8066,7 +7728,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-11-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-11-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -8092,7 +7754,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8110,7 +7772,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8130,14 +7792,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8156,7 +7818,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -8166,14 +7828,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8222,7 +7884,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8234,7 +7896,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8249,9 +7911,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8259,7 +7920,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-12-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-12-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -8285,7 +7946,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8303,7 +7964,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8323,14 +7984,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8349,7 +8010,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -8359,14 +8020,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8415,7 +8076,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8427,7 +8088,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8442,9 +8103,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8452,7 +8112,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-13-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-13-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -8478,7 +8138,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8496,7 +8156,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8516,14 +8176,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8542,7 +8202,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -8552,14 +8212,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8608,7 +8268,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8620,7 +8280,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8635,9 +8295,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8645,7 +8304,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-14-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-14-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -8671,7 +8330,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8689,7 +8348,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8709,14 +8368,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8735,7 +8394,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -8745,14 +8404,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8801,7 +8460,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8813,7 +8472,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8828,9 +8487,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8838,7 +8496,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-15-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-15-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -8864,7 +8522,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8882,7 +8540,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8902,14 +8560,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8928,7 +8586,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -8938,14 +8596,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8994,7 +8652,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9006,7 +8664,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9021,9 +8679,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9031,7 +8688,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-16-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-16-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -9057,7 +8714,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9075,7 +8732,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9095,14 +8752,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9121,7 +8778,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -9131,14 +8788,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9187,7 +8844,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9199,7 +8856,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9214,9 +8871,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9224,7 +8880,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-17-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-17-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -9250,7 +8906,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9268,7 +8924,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9288,14 +8944,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9314,7 +8970,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -9324,14 +8980,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9380,7 +9036,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9392,7 +9048,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9407,9 +9063,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9417,7 +9072,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-18-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-18-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -9443,7 +9098,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9461,7 +9116,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9481,14 +9136,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9507,7 +9162,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -9517,14 +9172,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9573,7 +9228,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9585,7 +9240,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9600,9 +9255,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9610,7 +9264,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-19-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-19-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -9636,7 +9290,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9654,7 +9308,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9674,14 +9328,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9700,7 +9354,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -9710,14 +9364,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9766,7 +9420,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9778,7 +9432,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9793,9 +9447,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9803,7 +9456,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-20-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-20-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -9829,7 +9482,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9847,7 +9500,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9867,14 +9520,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9893,7 +9546,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -9903,14 +9556,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9959,7 +9612,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9971,7 +9624,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9986,9 +9639,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -9996,7 +9648,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-21-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-21-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10022,7 +9674,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10040,7 +9692,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10060,14 +9712,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10086,7 +9738,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -10096,14 +9748,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10152,7 +9804,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10164,7 +9816,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10179,9 +9831,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -10189,7 +9840,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-22-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-22-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10215,7 +9866,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10233,7 +9884,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10253,14 +9904,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10279,7 +9930,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -10289,14 +9940,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10345,7 +9996,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10357,7 +10008,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10372,9 +10023,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -10382,7 +10032,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-23-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-23-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10408,7 +10058,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10426,7 +10076,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10446,14 +10096,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10472,7 +10122,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -10482,14 +10132,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10538,7 +10188,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10550,7 +10200,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10565,9 +10215,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -10575,7 +10224,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-24-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-24-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10601,7 +10250,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10619,7 +10268,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10639,14 +10288,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10665,7 +10314,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -10675,14 +10324,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10731,7 +10380,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10743,7 +10392,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10758,9 +10407,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -10768,7 +10416,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIall-25-25-latest-chrome-mariadb10.2-php7.0
+name: webUIall-25-25-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10794,7 +10442,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10812,7 +10460,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10832,14 +10480,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10858,7 +10506,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -10868,14 +10516,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10924,7 +10572,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10936,7 +10584,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10951,9 +10599,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -10961,7 +10608,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-1-master-mariadb10.2-php7.0
+name: apiAll-25-1-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -10987,7 +10634,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11005,7 +10652,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11025,14 +10672,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11051,7 +10698,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11061,14 +10708,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11102,7 +10749,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11114,7 +10761,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11131,9 +10778,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -11141,7 +10787,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-2-master-mariadb10.2-php7.0
+name: apiAll-25-2-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -11167,7 +10813,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11185,7 +10831,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11205,14 +10851,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11231,7 +10877,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11241,14 +10887,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11282,7 +10928,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11294,7 +10940,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11311,9 +10957,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -11321,7 +10966,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-3-master-mariadb10.2-php7.0
+name: apiAll-25-3-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -11347,7 +10992,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11365,7 +11010,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11385,14 +11030,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11411,7 +11056,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11421,14 +11066,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11462,7 +11107,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11474,7 +11119,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11491,9 +11136,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -11501,7 +11145,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-4-master-mariadb10.2-php7.0
+name: apiAll-25-4-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -11527,7 +11171,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11545,7 +11189,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11565,14 +11209,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11591,7 +11235,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11601,14 +11245,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11642,7 +11286,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11654,7 +11298,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11671,9 +11315,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -11681,7 +11324,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-5-master-mariadb10.2-php7.0
+name: apiAll-25-5-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -11707,7 +11350,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11725,7 +11368,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11745,14 +11388,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11771,7 +11414,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11781,14 +11424,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11822,7 +11465,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11834,7 +11477,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11851,9 +11494,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -11861,7 +11503,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-6-master-mariadb10.2-php7.0
+name: apiAll-25-6-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -11887,7 +11529,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11905,7 +11547,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11925,14 +11567,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11951,7 +11593,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -11961,14 +11603,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12002,7 +11644,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12014,7 +11656,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12031,9 +11673,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12041,7 +11682,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-7-master-mariadb10.2-php7.0
+name: apiAll-25-7-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12067,7 +11708,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12085,7 +11726,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12105,14 +11746,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12131,7 +11772,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -12141,14 +11782,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12182,7 +11823,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12194,7 +11835,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12211,9 +11852,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12221,7 +11861,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-8-master-mariadb10.2-php7.0
+name: apiAll-25-8-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12247,7 +11887,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12265,7 +11905,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12285,14 +11925,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12311,7 +11951,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -12321,14 +11961,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12362,7 +12002,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12374,7 +12014,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12391,9 +12031,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12401,7 +12040,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-9-master-mariadb10.2-php7.0
+name: apiAll-25-9-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12427,7 +12066,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12445,7 +12084,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12465,14 +12104,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12491,7 +12130,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -12501,14 +12140,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12542,7 +12181,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12554,7 +12193,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12571,9 +12210,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12581,7 +12219,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-10-master-mariadb10.2-php7.0
+name: apiAll-25-10-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12607,7 +12245,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12625,7 +12263,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12645,14 +12283,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12671,7 +12309,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -12681,14 +12319,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12722,7 +12360,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12734,7 +12372,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12751,9 +12389,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12761,7 +12398,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-11-master-mariadb10.2-php7.0
+name: apiAll-25-11-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12787,7 +12424,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12805,7 +12442,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12825,14 +12462,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12851,7 +12488,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -12861,14 +12498,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12902,7 +12539,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12914,7 +12551,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12931,9 +12568,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -12941,7 +12577,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-12-master-mariadb10.2-php7.0
+name: apiAll-25-12-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -12967,7 +12603,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12985,7 +12621,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13005,14 +12641,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13031,7 +12667,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13041,14 +12677,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13082,7 +12718,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13094,7 +12730,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13111,9 +12747,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -13121,7 +12756,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-13-master-mariadb10.2-php7.0
+name: apiAll-25-13-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -13147,7 +12782,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13165,7 +12800,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13185,14 +12820,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13211,7 +12846,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13221,14 +12856,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13262,7 +12897,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13274,7 +12909,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13291,9 +12926,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -13301,7 +12935,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-14-master-mariadb10.2-php7.0
+name: apiAll-25-14-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -13327,7 +12961,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13345,7 +12979,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13365,14 +12999,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13391,7 +13025,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13401,14 +13035,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13442,7 +13076,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13454,7 +13088,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13471,9 +13105,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -13481,7 +13114,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-15-master-mariadb10.2-php7.0
+name: apiAll-25-15-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -13507,7 +13140,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13525,7 +13158,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13545,14 +13178,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13571,7 +13204,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13581,14 +13214,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13622,7 +13255,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13634,7 +13267,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13651,9 +13284,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -13661,7 +13293,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-16-master-mariadb10.2-php7.0
+name: apiAll-25-16-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -13687,7 +13319,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13705,7 +13337,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13725,14 +13357,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13751,7 +13383,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13761,14 +13393,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13802,7 +13434,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13814,7 +13446,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13831,9 +13463,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -13841,7 +13472,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-17-master-mariadb10.2-php7.0
+name: apiAll-25-17-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -13867,7 +13498,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13885,7 +13516,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13905,14 +13536,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13931,7 +13562,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -13941,14 +13572,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13982,7 +13613,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13994,7 +13625,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14011,9 +13642,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14021,7 +13651,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-18-master-mariadb10.2-php7.0
+name: apiAll-25-18-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14047,7 +13677,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14065,7 +13695,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14085,14 +13715,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14111,7 +13741,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -14121,14 +13751,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14162,7 +13792,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14174,7 +13804,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14191,9 +13821,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14201,7 +13830,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-19-master-mariadb10.2-php7.0
+name: apiAll-25-19-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14227,7 +13856,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14245,7 +13874,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14265,14 +13894,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14291,7 +13920,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -14301,14 +13930,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14342,7 +13971,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14354,7 +13983,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14371,9 +14000,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14381,7 +14009,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-20-master-mariadb10.2-php7.0
+name: apiAll-25-20-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14407,7 +14035,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14425,7 +14053,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14445,14 +14073,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14471,7 +14099,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -14481,14 +14109,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14522,7 +14150,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14534,7 +14162,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14551,9 +14179,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14561,7 +14188,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-21-master-mariadb10.2-php7.0
+name: apiAll-25-21-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14587,7 +14214,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14605,7 +14232,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14625,14 +14252,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14651,7 +14278,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -14661,14 +14288,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14702,7 +14329,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14714,7 +14341,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14731,9 +14358,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14741,7 +14367,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-22-master-mariadb10.2-php7.0
+name: apiAll-25-22-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14767,7 +14393,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14785,7 +14411,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14805,14 +14431,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14831,7 +14457,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -14841,14 +14467,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14882,7 +14508,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14894,7 +14520,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14911,9 +14537,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -14921,7 +14546,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-23-master-mariadb10.2-php7.0
+name: apiAll-25-23-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -14947,7 +14572,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14965,7 +14590,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14985,14 +14610,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15011,7 +14636,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15021,14 +14646,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15062,7 +14687,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15074,7 +14699,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15091,9 +14716,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15101,7 +14725,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-24-master-mariadb10.2-php7.0
+name: apiAll-25-24-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -15127,7 +14751,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15145,7 +14769,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15165,14 +14789,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15191,7 +14815,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15201,14 +14825,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15242,7 +14866,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15254,7 +14878,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15271,9 +14895,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15281,7 +14904,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-25-master-mariadb10.2-php7.0
+name: apiAll-25-25-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -15307,7 +14930,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15325,7 +14948,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15345,14 +14968,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15371,7 +14994,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15381,14 +15004,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15422,7 +15045,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15434,7 +15057,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15451,9 +15074,8 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15461,7 +15083,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-1-latest-mariadb10.2-php7.0
+name: apiAll-25-1-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -15487,7 +15109,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15505,7 +15127,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15525,14 +15147,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15551,7 +15173,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15561,14 +15183,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15602,7 +15224,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15614,7 +15236,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15629,9 +15251,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15639,7 +15260,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-2-latest-mariadb10.2-php7.0
+name: apiAll-25-2-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -15665,7 +15286,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15683,7 +15304,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15703,14 +15324,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15729,7 +15350,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15739,14 +15360,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15780,7 +15401,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15792,7 +15413,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15807,9 +15428,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15817,7 +15437,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-3-latest-mariadb10.2-php7.0
+name: apiAll-25-3-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -15843,7 +15463,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15861,7 +15481,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15881,14 +15501,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15907,7 +15527,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -15917,14 +15537,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15958,7 +15578,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15970,7 +15590,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15985,9 +15605,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -15995,7 +15614,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-4-latest-mariadb10.2-php7.0
+name: apiAll-25-4-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16021,7 +15640,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16039,7 +15658,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16059,14 +15678,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16085,7 +15704,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16095,14 +15714,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16136,7 +15755,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16148,7 +15767,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16163,9 +15782,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -16173,7 +15791,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-5-latest-mariadb10.2-php7.0
+name: apiAll-25-5-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16199,7 +15817,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16217,7 +15835,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16237,14 +15855,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16263,7 +15881,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16273,14 +15891,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16314,7 +15932,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16326,7 +15944,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16341,9 +15959,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -16351,7 +15968,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-6-latest-mariadb10.2-php7.0
+name: apiAll-25-6-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16377,7 +15994,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16395,7 +16012,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16415,14 +16032,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16441,7 +16058,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16451,14 +16068,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16492,7 +16109,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16504,7 +16121,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16519,9 +16136,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -16529,7 +16145,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-7-latest-mariadb10.2-php7.0
+name: apiAll-25-7-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16555,7 +16171,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16573,7 +16189,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16593,14 +16209,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16619,7 +16235,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16629,14 +16245,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16670,7 +16286,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16682,7 +16298,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16697,9 +16313,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -16707,7 +16322,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-8-latest-mariadb10.2-php7.0
+name: apiAll-25-8-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16733,7 +16348,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16751,7 +16366,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16771,14 +16386,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16797,7 +16412,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16807,14 +16422,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16848,7 +16463,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16860,7 +16475,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16875,9 +16490,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -16885,7 +16499,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-9-latest-mariadb10.2-php7.0
+name: apiAll-25-9-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -16911,7 +16525,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16929,7 +16543,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16949,14 +16563,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16975,7 +16589,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -16985,14 +16599,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17026,7 +16640,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17038,7 +16652,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17053,9 +16667,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17063,7 +16676,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-10-latest-mariadb10.2-php7.0
+name: apiAll-25-10-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17089,7 +16702,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17107,7 +16720,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17127,14 +16740,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17153,7 +16766,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -17163,14 +16776,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17204,7 +16817,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17216,7 +16829,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17231,9 +16844,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17241,7 +16853,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-11-latest-mariadb10.2-php7.0
+name: apiAll-25-11-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17267,7 +16879,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17285,7 +16897,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17305,14 +16917,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17331,7 +16943,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -17341,14 +16953,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17382,7 +16994,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17394,7 +17006,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17409,9 +17021,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17419,7 +17030,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-12-latest-mariadb10.2-php7.0
+name: apiAll-25-12-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17445,7 +17056,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17463,7 +17074,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17483,14 +17094,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17509,7 +17120,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -17519,14 +17130,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17560,7 +17171,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17572,7 +17183,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17587,9 +17198,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17597,7 +17207,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-13-latest-mariadb10.2-php7.0
+name: apiAll-25-13-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17623,7 +17233,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17641,7 +17251,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17661,14 +17271,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17687,7 +17297,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -17697,14 +17307,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17738,7 +17348,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17750,7 +17360,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17765,9 +17375,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17775,7 +17384,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-14-latest-mariadb10.2-php7.0
+name: apiAll-25-14-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17801,7 +17410,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17819,7 +17428,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17839,14 +17448,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17865,7 +17474,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -17875,14 +17484,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17916,7 +17525,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17928,7 +17537,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17943,9 +17552,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -17953,7 +17561,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-15-latest-mariadb10.2-php7.0
+name: apiAll-25-15-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -17979,7 +17587,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17997,7 +17605,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18017,14 +17625,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18043,7 +17651,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18053,14 +17661,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18094,7 +17702,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18106,7 +17714,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18121,9 +17729,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -18131,7 +17738,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-16-latest-mariadb10.2-php7.0
+name: apiAll-25-16-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -18157,7 +17764,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -18175,7 +17782,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18195,14 +17802,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18221,7 +17828,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18231,14 +17838,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18272,7 +17879,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18284,7 +17891,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18299,9 +17906,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -18309,7 +17915,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-17-latest-mariadb10.2-php7.0
+name: apiAll-25-17-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -18335,7 +17941,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -18353,7 +17959,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18373,14 +17979,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18399,7 +18005,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18409,14 +18015,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18450,7 +18056,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18462,7 +18068,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18477,9 +18083,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -18487,7 +18092,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-18-latest-mariadb10.2-php7.0
+name: apiAll-25-18-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -18513,7 +18118,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -18531,7 +18136,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18551,14 +18156,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18577,7 +18182,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18587,14 +18192,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18628,7 +18233,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18640,7 +18245,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18655,9 +18260,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -18665,7 +18269,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-19-latest-mariadb10.2-php7.0
+name: apiAll-25-19-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -18691,7 +18295,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -18709,7 +18313,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18729,14 +18333,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18755,7 +18359,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18765,14 +18369,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18806,7 +18410,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18818,7 +18422,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18833,9 +18437,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -18843,7 +18446,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-20-latest-mariadb10.2-php7.0
+name: apiAll-25-20-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -18869,7 +18472,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -18887,7 +18490,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -18907,14 +18510,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -18933,7 +18536,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -18943,14 +18546,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -18984,7 +18587,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -18996,7 +18599,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19011,9 +18614,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19021,7 +18623,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-21-latest-mariadb10.2-php7.0
+name: apiAll-25-21-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -19047,7 +18649,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -19065,7 +18667,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -19085,14 +18687,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -19111,7 +18713,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -19121,14 +18723,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -19162,7 +18764,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19174,7 +18776,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19189,9 +18791,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19199,7 +18800,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-22-latest-mariadb10.2-php7.0
+name: apiAll-25-22-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -19225,7 +18826,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -19243,7 +18844,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -19263,14 +18864,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -19289,7 +18890,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -19299,14 +18900,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -19340,7 +18941,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19352,7 +18953,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19367,9 +18968,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19377,7 +18977,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-23-latest-mariadb10.2-php7.0
+name: apiAll-25-23-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -19403,7 +19003,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -19421,7 +19021,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -19441,14 +19041,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -19467,7 +19067,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -19477,14 +19077,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -19518,7 +19118,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19530,7 +19130,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19545,9 +19145,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19555,7 +19154,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-24-latest-mariadb10.2-php7.0
+name: apiAll-25-24-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -19581,7 +19180,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -19599,7 +19198,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -19619,14 +19218,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -19645,7 +19244,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -19655,14 +19254,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -19696,7 +19295,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19708,7 +19307,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19723,9 +19322,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19733,7 +19331,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAll-25-25-latest-mariadb10.2-php7.0
+name: apiAll-25-25-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -19759,7 +19357,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -19777,7 +19375,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -19797,14 +19395,14 @@ steps:
 
 - name: install-app-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - composer install
 
 - name: setup-server-files_primary_s3
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -19823,7 +19421,7 @@ steps:
 
 - name: setup-ceph
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - wait-for-it -t 120 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
@@ -19833,14 +19431,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -19874,7 +19472,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19886,7 +19484,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -19901,9 +19499,8 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
+- coding-standard-php7.1
 - phpstan-php7.2
-- phan-php7.0
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -19938,117 +19535,114 @@ trigger:
   - failure
 
 depends_on:
-- phpunit-scality-php7.0-sqlite
 - phpunit-scality-php7.1-sqlite
 - phpunit-scality-php7.2-sqlite
 - phpunit-scality-php7.3-sqlite
-- phpunit-scality-multibucket-php7.0-sqlite
 - phpunit-scality-multibucket-php7.1-sqlite
 - phpunit-scality-multibucket-php7.2-sqlite
 - phpunit-scality-multibucket-php7.3-sqlite
-- phpunit-ceph-php7.0-sqlite
 - phpunit-ceph-php7.1-sqlite
 - phpunit-ceph-php7.2-sqlite
 - phpunit-ceph-php7.3-sqlite
-- webUIall-25-1-master-chrome-mariadb10.2-php7.0
-- webUIall-25-2-master-chrome-mariadb10.2-php7.0
-- webUIall-25-3-master-chrome-mariadb10.2-php7.0
-- webUIall-25-4-master-chrome-mariadb10.2-php7.0
-- webUIall-25-5-master-chrome-mariadb10.2-php7.0
-- webUIall-25-6-master-chrome-mariadb10.2-php7.0
-- webUIall-25-7-master-chrome-mariadb10.2-php7.0
-- webUIall-25-8-master-chrome-mariadb10.2-php7.0
-- webUIall-25-9-master-chrome-mariadb10.2-php7.0
-- webUIall-25-10-master-chrome-mariadb10.2-php7.0
-- webUIall-25-11-master-chrome-mariadb10.2-php7.0
-- webUIall-25-12-master-chrome-mariadb10.2-php7.0
-- webUIall-25-13-master-chrome-mariadb10.2-php7.0
-- webUIall-25-14-master-chrome-mariadb10.2-php7.0
-- webUIall-25-15-master-chrome-mariadb10.2-php7.0
-- webUIall-25-16-master-chrome-mariadb10.2-php7.0
-- webUIall-25-17-master-chrome-mariadb10.2-php7.0
-- webUIall-25-18-master-chrome-mariadb10.2-php7.0
-- webUIall-25-19-master-chrome-mariadb10.2-php7.0
-- webUIall-25-20-master-chrome-mariadb10.2-php7.0
-- webUIall-25-21-master-chrome-mariadb10.2-php7.0
-- webUIall-25-22-master-chrome-mariadb10.2-php7.0
-- webUIall-25-23-master-chrome-mariadb10.2-php7.0
-- webUIall-25-24-master-chrome-mariadb10.2-php7.0
-- webUIall-25-25-master-chrome-mariadb10.2-php7.0
-- webUIall-25-1-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-2-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-3-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-4-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-5-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-6-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-7-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-8-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-9-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-10-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-11-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-12-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-13-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-14-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-15-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-16-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-17-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-18-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-19-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-20-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-21-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-22-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-23-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-24-latest-chrome-mariadb10.2-php7.0
-- webUIall-25-25-latest-chrome-mariadb10.2-php7.0
-- apiAll-25-1-master-mariadb10.2-php7.0
-- apiAll-25-2-master-mariadb10.2-php7.0
-- apiAll-25-3-master-mariadb10.2-php7.0
-- apiAll-25-4-master-mariadb10.2-php7.0
-- apiAll-25-5-master-mariadb10.2-php7.0
-- apiAll-25-6-master-mariadb10.2-php7.0
-- apiAll-25-7-master-mariadb10.2-php7.0
-- apiAll-25-8-master-mariadb10.2-php7.0
-- apiAll-25-9-master-mariadb10.2-php7.0
-- apiAll-25-10-master-mariadb10.2-php7.0
-- apiAll-25-11-master-mariadb10.2-php7.0
-- apiAll-25-12-master-mariadb10.2-php7.0
-- apiAll-25-13-master-mariadb10.2-php7.0
-- apiAll-25-14-master-mariadb10.2-php7.0
-- apiAll-25-15-master-mariadb10.2-php7.0
-- apiAll-25-16-master-mariadb10.2-php7.0
-- apiAll-25-17-master-mariadb10.2-php7.0
-- apiAll-25-18-master-mariadb10.2-php7.0
-- apiAll-25-19-master-mariadb10.2-php7.0
-- apiAll-25-20-master-mariadb10.2-php7.0
-- apiAll-25-21-master-mariadb10.2-php7.0
-- apiAll-25-22-master-mariadb10.2-php7.0
-- apiAll-25-23-master-mariadb10.2-php7.0
-- apiAll-25-24-master-mariadb10.2-php7.0
-- apiAll-25-25-master-mariadb10.2-php7.0
-- apiAll-25-1-latest-mariadb10.2-php7.0
-- apiAll-25-2-latest-mariadb10.2-php7.0
-- apiAll-25-3-latest-mariadb10.2-php7.0
-- apiAll-25-4-latest-mariadb10.2-php7.0
-- apiAll-25-5-latest-mariadb10.2-php7.0
-- apiAll-25-6-latest-mariadb10.2-php7.0
-- apiAll-25-7-latest-mariadb10.2-php7.0
-- apiAll-25-8-latest-mariadb10.2-php7.0
-- apiAll-25-9-latest-mariadb10.2-php7.0
-- apiAll-25-10-latest-mariadb10.2-php7.0
-- apiAll-25-11-latest-mariadb10.2-php7.0
-- apiAll-25-12-latest-mariadb10.2-php7.0
-- apiAll-25-13-latest-mariadb10.2-php7.0
-- apiAll-25-14-latest-mariadb10.2-php7.0
-- apiAll-25-15-latest-mariadb10.2-php7.0
-- apiAll-25-16-latest-mariadb10.2-php7.0
-- apiAll-25-17-latest-mariadb10.2-php7.0
-- apiAll-25-18-latest-mariadb10.2-php7.0
-- apiAll-25-19-latest-mariadb10.2-php7.0
-- apiAll-25-20-latest-mariadb10.2-php7.0
-- apiAll-25-21-latest-mariadb10.2-php7.0
-- apiAll-25-22-latest-mariadb10.2-php7.0
-- apiAll-25-23-latest-mariadb10.2-php7.0
-- apiAll-25-24-latest-mariadb10.2-php7.0
-- apiAll-25-25-latest-mariadb10.2-php7.0
+- webUIall-25-1-master-chrome-mariadb10.2-php7.1
+- webUIall-25-2-master-chrome-mariadb10.2-php7.1
+- webUIall-25-3-master-chrome-mariadb10.2-php7.1
+- webUIall-25-4-master-chrome-mariadb10.2-php7.1
+- webUIall-25-5-master-chrome-mariadb10.2-php7.1
+- webUIall-25-6-master-chrome-mariadb10.2-php7.1
+- webUIall-25-7-master-chrome-mariadb10.2-php7.1
+- webUIall-25-8-master-chrome-mariadb10.2-php7.1
+- webUIall-25-9-master-chrome-mariadb10.2-php7.1
+- webUIall-25-10-master-chrome-mariadb10.2-php7.1
+- webUIall-25-11-master-chrome-mariadb10.2-php7.1
+- webUIall-25-12-master-chrome-mariadb10.2-php7.1
+- webUIall-25-13-master-chrome-mariadb10.2-php7.1
+- webUIall-25-14-master-chrome-mariadb10.2-php7.1
+- webUIall-25-15-master-chrome-mariadb10.2-php7.1
+- webUIall-25-16-master-chrome-mariadb10.2-php7.1
+- webUIall-25-17-master-chrome-mariadb10.2-php7.1
+- webUIall-25-18-master-chrome-mariadb10.2-php7.1
+- webUIall-25-19-master-chrome-mariadb10.2-php7.1
+- webUIall-25-20-master-chrome-mariadb10.2-php7.1
+- webUIall-25-21-master-chrome-mariadb10.2-php7.1
+- webUIall-25-22-master-chrome-mariadb10.2-php7.1
+- webUIall-25-23-master-chrome-mariadb10.2-php7.1
+- webUIall-25-24-master-chrome-mariadb10.2-php7.1
+- webUIall-25-25-master-chrome-mariadb10.2-php7.1
+- webUIall-25-1-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-2-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-3-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-4-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-5-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-6-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-7-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-8-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-9-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-10-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-11-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-12-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-13-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-14-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-15-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-16-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-17-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-18-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-19-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-20-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-21-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-22-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-23-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-24-latest-chrome-mariadb10.2-php7.1
+- webUIall-25-25-latest-chrome-mariadb10.2-php7.1
+- apiAll-25-1-master-mariadb10.2-php7.1
+- apiAll-25-2-master-mariadb10.2-php7.1
+- apiAll-25-3-master-mariadb10.2-php7.1
+- apiAll-25-4-master-mariadb10.2-php7.1
+- apiAll-25-5-master-mariadb10.2-php7.1
+- apiAll-25-6-master-mariadb10.2-php7.1
+- apiAll-25-7-master-mariadb10.2-php7.1
+- apiAll-25-8-master-mariadb10.2-php7.1
+- apiAll-25-9-master-mariadb10.2-php7.1
+- apiAll-25-10-master-mariadb10.2-php7.1
+- apiAll-25-11-master-mariadb10.2-php7.1
+- apiAll-25-12-master-mariadb10.2-php7.1
+- apiAll-25-13-master-mariadb10.2-php7.1
+- apiAll-25-14-master-mariadb10.2-php7.1
+- apiAll-25-15-master-mariadb10.2-php7.1
+- apiAll-25-16-master-mariadb10.2-php7.1
+- apiAll-25-17-master-mariadb10.2-php7.1
+- apiAll-25-18-master-mariadb10.2-php7.1
+- apiAll-25-19-master-mariadb10.2-php7.1
+- apiAll-25-20-master-mariadb10.2-php7.1
+- apiAll-25-21-master-mariadb10.2-php7.1
+- apiAll-25-22-master-mariadb10.2-php7.1
+- apiAll-25-23-master-mariadb10.2-php7.1
+- apiAll-25-24-master-mariadb10.2-php7.1
+- apiAll-25-25-master-mariadb10.2-php7.1
+- apiAll-25-1-latest-mariadb10.2-php7.1
+- apiAll-25-2-latest-mariadb10.2-php7.1
+- apiAll-25-3-latest-mariadb10.2-php7.1
+- apiAll-25-4-latest-mariadb10.2-php7.1
+- apiAll-25-5-latest-mariadb10.2-php7.1
+- apiAll-25-6-latest-mariadb10.2-php7.1
+- apiAll-25-7-latest-mariadb10.2-php7.1
+- apiAll-25-8-latest-mariadb10.2-php7.1
+- apiAll-25-9-latest-mariadb10.2-php7.1
+- apiAll-25-10-latest-mariadb10.2-php7.1
+- apiAll-25-11-latest-mariadb10.2-php7.1
+- apiAll-25-12-latest-mariadb10.2-php7.1
+- apiAll-25-13-latest-mariadb10.2-php7.1
+- apiAll-25-14-latest-mariadb10.2-php7.1
+- apiAll-25-15-latest-mariadb10.2-php7.1
+- apiAll-25-16-latest-mariadb10.2-php7.1
+- apiAll-25-17-latest-mariadb10.2-php7.1
+- apiAll-25-18-latest-mariadb10.2-php7.1
+- apiAll-25-19-latest-mariadb10.2-php7.1
+- apiAll-25-20-latest-mariadb10.2-php7.1
+- apiAll-25-21-latest-mariadb10.2-php7.1
+- apiAll-25-22-latest-mariadb10.2-php7.1
+- apiAll-25-23-latest-mariadb10.2-php7.1
+- apiAll-25-24-latest-mariadb10.2-php7.1
+- apiAll-25-25-latest-mariadb10.2-php7.1
 
 ...


### PR DESCRIPTION
Because core has dropped PHP 7.0 support https://github.com/owncloud/core/pull/36290