### PR TITLE
Increase wait-for-db timeout from 120 to 600 seconds

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1347,7 +1347,7 @@ def setupCeph(serviceParams):
 
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 120 ceph:80',
+		'wait-for-it -t 600 ceph:80',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 		'cd /var/www/owncloud/server',
@@ -1375,7 +1375,7 @@ def setupScality(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 120 scality:8000',
+		'wait-for-it -t 600 scality:8000',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
 		'cd /var/www/owncloud/server'

--- a/.drone.yml
+++ b/.drone.yml
@@ -249,7 +249,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -332,7 +332,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -415,7 +415,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -498,7 +498,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.multibucket.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -581,7 +581,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.multibucket.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -664,7 +664,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/scality.multibucket.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -747,7 +747,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -833,7 +833,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -919,7 +919,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -1048,7 +1048,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -1240,7 +1240,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -1432,7 +1432,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -1624,7 +1624,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -1816,7 +1816,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2008,7 +2008,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2200,7 +2200,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2392,7 +2392,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2584,7 +2584,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2776,7 +2776,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -2968,7 +2968,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -3160,7 +3160,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -3352,7 +3352,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -3544,7 +3544,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -3736,7 +3736,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -3928,7 +3928,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -4120,7 +4120,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -4312,7 +4312,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -4504,7 +4504,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -4696,7 +4696,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -4888,7 +4888,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -5080,7 +5080,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -5272,7 +5272,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -5464,7 +5464,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -5656,7 +5656,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -5848,7 +5848,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6038,7 +6038,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6228,7 +6228,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6418,7 +6418,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6608,7 +6608,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6798,7 +6798,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -6988,7 +6988,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -7178,7 +7178,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -7368,7 +7368,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -7558,7 +7558,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -7748,7 +7748,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -7938,7 +7938,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -8128,7 +8128,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -8318,7 +8318,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -8508,7 +8508,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -8698,7 +8698,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -8888,7 +8888,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -9078,7 +9078,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -9268,7 +9268,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -9458,7 +9458,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -9648,7 +9648,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -9838,7 +9838,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10028,7 +10028,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10218,7 +10218,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10408,7 +10408,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10598,7 +10598,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10775,7 +10775,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -10952,7 +10952,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -11129,7 +11129,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -11306,7 +11306,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -11483,7 +11483,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -11660,7 +11660,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -11837,7 +11837,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12014,7 +12014,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12191,7 +12191,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12368,7 +12368,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12545,7 +12545,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12722,7 +12722,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -12899,7 +12899,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13076,7 +13076,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13253,7 +13253,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13430,7 +13430,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13607,7 +13607,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13784,7 +13784,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -13961,7 +13961,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -14138,7 +14138,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -14315,7 +14315,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -14492,7 +14492,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -14669,7 +14669,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -14846,7 +14846,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15023,7 +15023,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15198,7 +15198,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15373,7 +15373,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15548,7 +15548,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15723,7 +15723,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -15898,7 +15898,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16073,7 +16073,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16248,7 +16248,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16423,7 +16423,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16598,7 +16598,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16773,7 +16773,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -16948,7 +16948,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17123,7 +17123,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17298,7 +17298,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17473,7 +17473,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17648,7 +17648,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17823,7 +17823,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -17998,7 +17998,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -18173,7 +18173,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -18348,7 +18348,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -18523,7 +18523,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -18698,7 +18698,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -18873,7 +18873,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -19048,7 +19048,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server
@@ -19223,7 +19223,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 ceph:80
+  - wait-for-it -t 600 ceph:80
   - cd /var/www/owncloud/server/apps/files_primary_s3
   - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
   - cd /var/www/owncloud/server


### PR DESCRIPTION
## Description
The drone agents are sometimes taking "a long time" (tm) to pull docker images. In particular this is a problem when it takes a long time to pull the database image (mariadb, postgresql, oracle...). The `install-core` step waits 120 seconds for the database to become available. If the pull took more than 2 minutes, then we get a timeout in `install-core` and the pipeline fails. That means the whole build fails and it has to be started all over again. That is very annoying.

This is seen mostly first thing in the morning, when the autoscaler starts new drone agents. Specially if a lot of drone agents get started at a similar time, they seem to be slow to pull each docker image the first time. After that, they have the docker images cached, so later pulls of the docker images do not have this time delay.

Since we know there is a very variable delay here, set the timeout to a high value (10 minutes = 600 seconds). That will avoid annoying unnecessary fails, while still providing a reasonable time-to-failure in the rare case where the database really did fail on startup.

## Motivation and Context

## How Has This Been Tested?
CI

Similar to https://github.com/owncloud/activity/pull/814