### PR TITLE
Drone: run Federation server on db other than sqlite

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -910,6 +910,7 @@ def acceptance():
 										environment['S3_TYPE'] = 'ceph'
 									if (params['scalityS3'] != False):
 										environment['S3_TYPE'] = 'scality'
+								federationDbSuffix = '-federated'
 
 								result = {
 									'kind': 'pipeline',
@@ -922,32 +923,7 @@ def acceptance():
 									'steps':
 										installCore(server, db, params['useBundledApp']) +
 										installTestrunner(phpVersion, params['useBundledApp']) +
-									([
-										{
-											'name': 'install-federation',
-											'image': 'owncloudci/core',
-											'pull': 'always',
-											'settings': {
-												'version': server,
-												'core_path': '/var/www/owncloud/federated'
-											}
-										},
-										{
-											'name': 'configure-federation',
-											'image': 'owncloudci/php:%s' % phpVersion,
-											'pull': 'always',
-											'commands': [
-												'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
-												'cd /var/www/owncloud/federated',
-												'php occ a:l',
-												'php occ a:e testing',
-												'php occ a:l',
-												'php occ config:system:set trusted_domains 1 --value=federated',
-												'php occ log:manage --level %s' % params['logLevel'],
-												'php occ config:list'
-											]
-										}
-									] + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
+										(installFederated(server, phpVersion, params['logLevel'], db, federationDbSuffix) + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
 										installApp(phpVersion) +
 										installExtraApps(phpVersion, params['extraApps']) +
 										setupServerAndApp(phpVersion, params['logLevel']) +
@@ -978,7 +954,10 @@ def acceptance():
 										scalityService(params['scalityS3']) +
 										params['extraServices'] +
 										owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False) +
-										(owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if params['federatedServerNeeded'] else []),
+										((
+											owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) +
+											databaseServiceForFederation(db, federationDbSuffix)
+										) if params['federatedServerNeeded'] else [] ),
 									'depends_on': [],
 									'trigger': {}
 								}
@@ -1419,3 +1398,68 @@ def dependsOn(earlierStages, nextStages):
 	for earlierStage in earlierStages:
 		for nextStage in nextStages:
 			nextStage['depends_on'].append(earlierStage['name'])
+
+def installFederated(federatedServerVersion, phpVersion, logLevel, db, dbSuffix = '-federated'):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db) + dbSuffix
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+	elif host == 'postgres':
+		dbType = 'pgsql'
+	elif host == 'oracle':
+		dbType = 'oci'
+	return [
+		{
+			'name': 'install-federated',
+			'image': 'owncloudci/core',
+			'pull': 'always',
+			'settings': {
+				'version': federatedServerVersion,
+				'core_path': '/var/www/owncloud/federated',
+				'db_type': 'mysql',
+				'db_name': database,
+				'db_host': host + dbSuffix,
+				'db_username': username,
+				'db_password': password
+			},
+		},
+		{
+			'name': 'configure-federation',
+			'image': 'owncloudci/php:%s' % phpVersion,
+			'pull': 'always',
+			'commands': [
+				'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
+				'cd /var/www/owncloud/federated',
+				'php occ a:l',
+				'php occ a:e testing',
+				'php occ a:l',
+				'php occ config:system:set trusted_domains 1 --value=federated',
+				'php occ log:manage --level %s' % logLevel,
+				'php occ config:list'
+			]
+		}
+	]
+
+def databaseServiceForFederation(db, suffix):
+	dbName = getDbName(db)
+
+	if dbName not in ['mariadb', 'mysql']:
+		print('Not implemented federated database for ', dbName)
+		return []
+
+	return [{
+		'name': dbName + suffix,
+		'image': db,
+		'pull': 'always',
+		'environment': {
+			'MYSQL_USER': getDbUsername(db),
+			'MYSQL_PASSWORD': getDbPassword(db),
+			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
+			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
+		}
+	}]

--- a/.drone.yml
+++ b/.drone.yml
@@ -991,11 +991,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -1133,6 +1138,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -1183,11 +1197,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -1325,6 +1344,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -1375,11 +1403,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -1517,6 +1550,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -1567,11 +1609,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -1709,6 +1756,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -1759,11 +1815,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -1901,6 +1962,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -1951,11 +2021,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -2093,6 +2168,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -2143,11 +2227,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -2285,6 +2374,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -2335,11 +2433,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -2477,6 +2580,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -2527,11 +2639,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -2669,6 +2786,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -2719,11 +2845,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -2861,6 +2992,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -2911,11 +3051,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -3053,6 +3198,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -3103,11 +3257,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -3245,6 +3404,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -3295,11 +3463,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -3437,6 +3610,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -3487,11 +3669,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -3629,6 +3816,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -3679,11 +3875,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -3821,6 +4022,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -3871,11 +4081,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4013,6 +4228,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -4063,11 +4287,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4205,6 +4434,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -4255,11 +4493,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4397,6 +4640,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -4447,11 +4699,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4589,6 +4846,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -4639,11 +4905,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4781,6 +5052,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -4831,11 +5111,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -4973,6 +5258,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5023,11 +5317,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -5165,6 +5464,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5215,11 +5523,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -5357,6 +5670,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5407,11 +5729,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -5549,6 +5876,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5599,11 +5935,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -5741,6 +6082,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5791,11 +6141,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -5933,6 +6288,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -5983,11 +6347,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -6125,6 +6494,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -6175,11 +6553,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -6318,6 +6701,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -6365,11 +6757,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -6508,6 +6905,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -6555,11 +6961,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -6698,6 +7109,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -6745,11 +7165,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -6888,6 +7313,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -6935,11 +7369,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -7078,6 +7517,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -7125,11 +7573,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -7268,6 +7721,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -7315,11 +7777,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -7458,6 +7925,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -7505,11 +7981,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -7648,6 +8129,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -7695,11 +8185,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -7838,6 +8333,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -7885,11 +8389,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8028,6 +8537,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -8075,11 +8593,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8218,6 +8741,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -8265,11 +8797,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8408,6 +8945,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -8455,11 +9001,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8598,6 +9149,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -8645,11 +9205,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8788,6 +9353,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -8835,11 +9409,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -8978,6 +9557,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9025,11 +9613,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -9168,6 +9761,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9215,11 +9817,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -9358,6 +9965,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9405,11 +10021,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -9548,6 +10169,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9595,11 +10225,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -9738,6 +10373,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9785,11 +10429,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -9928,6 +10577,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -9975,11 +10633,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -10118,6 +10781,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -10165,11 +10837,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -10308,6 +10985,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -10355,11 +11041,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -10498,6 +11189,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -10545,11 +11245,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -10688,6 +11393,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -10735,11 +11449,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -10878,6 +11597,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -10925,11 +11653,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -11068,6 +11801,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -11115,11 +11857,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -11258,6 +12005,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -11305,11 +12061,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -11432,6 +12193,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -11482,11 +12252,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -11610,6 +12385,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -11659,11 +12443,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -11787,6 +12576,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -11836,11 +12634,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -11964,6 +12767,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12013,11 +12825,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -12141,6 +12958,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12190,11 +13016,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -12318,6 +13149,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12367,11 +13207,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -12495,6 +13340,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12544,11 +13398,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -12672,6 +13531,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12721,11 +13589,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -12849,6 +13722,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -12898,11 +13780,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13026,6 +13913,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13075,11 +13971,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13203,6 +14104,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13252,11 +14162,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13380,6 +14295,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13429,11 +14353,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13557,6 +14486,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13606,11 +14544,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13734,6 +14677,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13783,11 +14735,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -13911,6 +14868,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -13960,11 +14926,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14088,6 +15059,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -14137,11 +15117,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14265,6 +15250,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -14314,11 +15308,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14442,6 +15441,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -14491,11 +15499,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14619,6 +15632,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -14668,11 +15690,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14796,6 +15823,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -14845,11 +15881,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -14973,6 +16014,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15022,11 +16072,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -15150,6 +16205,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15199,11 +16263,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -15327,6 +16396,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15376,11 +16454,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -15504,6 +16587,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15553,11 +16645,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -15681,6 +16778,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15730,11 +16836,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -15858,6 +16969,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -15907,11 +17027,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16035,6 +17160,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16084,11 +17218,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16212,6 +17351,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16261,11 +17409,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16389,6 +17542,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16438,11 +17600,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16566,6 +17733,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16615,11 +17791,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16743,6 +17924,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16792,11 +17982,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: configure-federation
@@ -16920,6 +18115,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   ref:
   - refs/pull/**
@@ -16969,11 +18173,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17097,6 +18306,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -17144,11 +18362,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17272,6 +18495,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -17319,11 +18551,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17447,6 +18684,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -17494,11 +18740,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17622,6 +18873,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -17669,11 +18929,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17797,6 +19062,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -17844,11 +19118,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -17972,6 +19251,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18019,11 +19307,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -18147,6 +19440,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18194,11 +19496,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -18322,6 +19629,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18369,11 +19685,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -18497,6 +19818,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18544,11 +19874,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -18672,6 +20007,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18719,11 +20063,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -18847,6 +20196,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -18894,11 +20252,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19022,6 +20385,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19069,11 +20441,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19197,6 +20574,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19244,11 +20630,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19372,6 +20763,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19419,11 +20819,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19547,6 +20952,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19594,11 +21008,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19722,6 +21141,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19769,11 +21197,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -19897,6 +21330,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -19944,11 +21386,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20072,6 +21519,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20119,11 +21575,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20247,6 +21708,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20294,11 +21764,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20422,6 +21897,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20469,11 +21953,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20597,6 +22086,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20644,11 +22142,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20772,6 +22275,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20819,11 +22331,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -20947,6 +22464,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -20994,11 +22520,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21122,6 +22653,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -21169,11 +22709,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21297,6 +22842,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -21344,11 +22898,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21472,6 +23031,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -21519,11 +23087,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21647,6 +23220,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -21694,11 +23276,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21822,6 +23409,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -21869,11 +23465,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -21997,6 +23598,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -22044,11 +23654,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -22172,6 +23787,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -22219,11 +23843,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -22347,6 +23976,15 @@ services:
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
 trigger:
   cron:
   - nightly
@@ -22394,11 +24032,16 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
 
-- name: install-federation
+- name: install-federated
   pull: always
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
+    db_host: mariadb-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: latest
 
 - name: configure-federation
@@ -22521,6 +24164,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated
+
+- name: mariadb-federated
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 trigger:
   cron:


### PR DESCRIPTION
Fixes #299

Use Mysql server to run the federation server for federated tests.
Using sqlite just like in current setup results in unreliable tests.