### PR TITLE
Add phpdoc for Symfony Command execute

### DIFF
--- a/lib/command/createbucket.php
+++ b/lib/command/createbucket.php
@@ -53,6 +53,14 @@ class createBucket extends Command {
 			->addOption('accept-warning', null, InputOption::VALUE_NONE, 'No warning about the usage of this command will be displayed');
 	}
 
+	/**
+	 * Executes the current command.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|null|void
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if (!$input->getOption('accept-warning')) {
 			$helper = new QuestionHelper();

--- a/lib/command/s3list.php
+++ b/lib/command/s3list.php
@@ -49,6 +49,14 @@ class s3List extends Command {
 			->addArgument('object', InputArgument::OPTIONAL, 'Key of the object; it`s versions will be listed');
 	}
 
+	/**
+	 * Executes the current command.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|null|void
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$client = $this->getClient();
 


### PR DESCRIPTION
`phan` complains:
https://drone.owncloud.com/owncloud/files_primary_s3/1468/3/3
```
php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan --config-file .phan/config.php --require-config-exists
lib/command/s3list.php:52 PhanTypeMissingReturn Method \OCA\Files_Primary_S3\Command\s3List::execute is declared to return int but has no return value
Makefile:115: recipe for target 'test-php-phan' failed
```

Similar to https://github.com/owncloud/data_exporter/pull/139

I added phpdoc to both `createbucket` and `s3list`. I don't know why `phan` only complained about `s3list`