### PR TITLE
[Tests-Only] Run core PHP unit tests from core tests dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ test-php-codecheck:
 .PHONY: test-php-unit
 test-php-unit: ## Run core php unit tests
 test-php-unit:
-	cd ../../ && $(PHPUNIT) --configuration ./tests/phpunit-autotest.xml
+	cd ../../tests && $(PHPUNIT) --configuration ./phpunit-autotest.xml
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg: ## Run core php unit tests using phpdbg
 test-php-unit-dbg:
-	cd ../../ && $(PHPUNITDBG) --configuration ./tests/phpunit-autotest.xml
+	cd ../../tests && $(PHPUNITDBG) --configuration ./phpunit-autotest.xml
 
 .PHONY: test-php-style
 test-php-style: ## Run php-cs-fixer and check owncloud code-style


### PR DESCRIPTION
Drone https://drone.owncloud.com/owncloud/files_primary_s3/1828/6/7 failed last night running the PHP unit tests from core.
```
There was 1 error:

1) Tests\Core\Command\Security\RemoveCertificateTest::testRemoveCertificate
file_get_contents(data/certificates/goodCertificate.crt): failed to open stream: No such file or directory

/var/www/owncloud/server/tests/Core/Command/Security/RemoveCertificateTest.php:82

--

There was 1 failure:

1) Tests\Core\Command\Security\ImportCertificateTest::testCommandInput with data set #1 (array('data/certificates/goodCertificate.crt'), array(), 0, '')
Failed asserting that 1 matches expected 0.

/var/www/owncloud/server/tests/Core/Command/Security/ImportCertificateTest.php:69
```

Those tests are new in core. They use certificates that are in the core `tests/data/certificates` folder.

In core, the PHP unit tests are run with core `build/autotest.sh` script. Among other things, that does `cd tests` to get into the core `tests` directory before actually running the PHP unit tests. So the tests look for `data/certificates` to find the certificates.

`files_primary_s3` `Makefile` does not use core `build/autotest.sh`. It directly runs the PHP unit tests, but starting from the top-level core folder.

To fix this, and minimize future issues, change to the core `tests` directory before running the PHP unit tests. That makes the test environment more similar to the way it works in core.

Note:  I am not going to try running core `build/autotest.sh` from this repo - that would be a task for another day!