### PR TITLE
[Tests-Only] Add restoreVersion tests for issue 387

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -67,6 +67,12 @@ config = {
 	},
 
 	'acceptance': {
+        'api': {
+            'suites': {
+                'apiFilesPrimaryS3': 'apiFilesPriS3'
+            },
+            'cephS3': True,
+        },
         'webUI': {
             'suites': {
                 'webUIFilesPrimaryS3': 'webUIFilesPriS3'

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -21,6 +21,8 @@ default:
             adminPassword: admin
             ocPath: apps/testing/api/v1/occ
             regularUserPassword: 123456
+        - WebDavPropertiesContext:
+        - FilesVersionsContext:
 
     webUIFilesPrimaryS3:
       paths:

--- a/tests/acceptance/features/apiFilesPrimaryS3/restoreVersion.feature
+++ b/tests/acceptance/features/apiFilesPrimaryS3/restoreVersion.feature
@@ -1,0 +1,23 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when restoring a version of a file
+
+  Background:
+    Given using OCS API version "2"
+    And using new DAV path
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  @issue-files_primary_s3-387
+  Scenario Outline: Restoring a file changes the etags of all parents
+    Given user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has uploaded file with content "changed content" to "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores version index "1" of file "/upload/sub/file.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should not have changed
+    # Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | element    |
+      |            |
+      | upload     |
+      | upload/sub |


### PR DESCRIPTION
That demonstrate the current "bad behaviour" of issue #387 

The corresponding "good" tests in core are skipped by core PR https://github.com/owncloud/core/pull/37969

When fixing the issue, those core restoreVersion tests need to be unskipped and made to pass. And the "bad behaviour" scenarios in this PR should fail, and can be deleted.

Note: `apiFilesPrimaryS3` already exists in `behat.yml` but it has no scenarios, so it was not being run in CI. This PR adds the suite to drone CI.