### PR TITLE
Update PHP dependencies for composer 2.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1028,7 +1028,7 @@ def acceptance():
 									},
 									'steps':
 										installCore(server, db, params['useBundledApp']) +
-										installTestrunner(phpVersion, params['useBundledApp']) +
+										installTestrunner('7.4', params['useBundledApp']) +
 										(installFederated(server, phpVersion, params['logLevel'], db, federationDbSuffix) + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
 										installApp(phpVersion) +
 										installExtraApps(phpVersion, params['extraApps']) +
@@ -1041,7 +1041,7 @@ def acceptance():
 									[
 										({
 											'name': 'acceptance-tests',
-											'image': 'owncloudci/php:%s' % phpVersion,
+											'image': 'owncloudci/php:7.4',
 											'pull': 'always',
 											'environment': environment,
 											'commands': params['extraCommandsBeforeTestRun'] + [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "optimize-autoloader": true,
     "classmap-authoritative": false,
     "platform": {
-      "php": "7.0.8"
+      "php": "7.1"
     }
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "679b586064f8128ac9241649f3948a43",
+    "content-hash": "55545a37c6224232a1faab0cd1142156",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.158.14",
+            "version": "3.158.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "8eb1bfc65424c40e4d66d6ec71f5add6d91993b4"
+                "reference": "75aebc2f5dfd23ad7272ff1d59c521bc2a8e2802"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/8eb1bfc65424c40e4d66d6ec71f5add6d91993b4",
-                "reference": "8eb1bfc65424c40e4d66d6ec71f5add6d91993b4",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/75aebc2f5dfd23ad7272ff1d59c521bc2a8e2802",
+                "reference": "75aebc2f5dfd23ad7272ff1d59c521bc2a8e2802",
                 "shasum": ""
             },
             "require": {
@@ -89,28 +89,35 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-10-26T18:18:44+00:00"
+            "support": {
+                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.158.18"
+            },
+            "time": "2020-10-30T18:12:38+00:00"
         },
         {
             "name": "dg/composer-cleaner",
-            "version": "v2.1",
+            "version": "v2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dg/composer-cleaner.git",
-                "reference": "91f865f0b50c66dd647955a0e5ba7745d8086945"
+                "reference": "f1e72fb72a37014e421451185550750205993185"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dg/composer-cleaner/zipball/91f865f0b50c66dd647955a0e5ba7745d8086945",
-                "reference": "91f865f0b50c66dd647955a0e5ba7745d8086945",
+                "url": "https://api.github.com/repos/dg/composer-cleaner/zipball/f1e72fb72a37014e421451185550750205993185",
+                "reference": "f1e72fb72a37014e421451185550750205993185",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": ">=5.4.0"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=7.1"
             },
             "require-dev": {
-                "nette/tester": "^1.7"
+                "composer/composer": "^1.10 || ^2.0",
+                "nette/tester": "^2.2",
+                "phpstan/phpstan": "^0.12"
             },
             "type": "composer-plugin",
             "extra": {
@@ -135,7 +142,11 @@
             "keywords": [
                 "composer"
             ],
-            "time": "2019-02-05T21:18:31+00:00"
+            "support": {
+                "issues": "https://github.com/dg/composer-cleaner/issues",
+                "source": "https://github.com/dg/composer-cleaner/tree/v2.2"
+            },
+            "time": "2020-10-27T13:01:26+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -186,6 +197,10 @@
             "keywords": [
                 "promise"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.0"
+            },
             "time": "2020-09-30T07:37:28+00:00"
         },
         {
@@ -257,6 +272,10 @@
                 "uri",
                 "url"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.7.0"
+            },
             "time": "2020-09-30T07:37:11+00:00"
         },
         {
@@ -314,6 +333,10 @@
                 "json",
                 "jsonpath"
             ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.6.0"
+            },
             "time": "2020-07-31T21:01:56+00:00"
         },
         {
@@ -364,6 +387,9 @@
                 "request",
                 "response"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
@@ -404,24 +430,28 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.19.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b5f7b932ee6fa802fc792eabd77c4c88084517ce"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b5f7b932ee6fa802fc792eabd77c4c88084517ce",
-                "reference": "b5f7b932ee6fa802fc792eabd77c4c88084517ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -429,7 +459,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.19-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -467,6 +497,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -481,7 +514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T09:01:57+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         }
     ],
     "packages-dev": [
@@ -529,6 +562,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -540,7 +577,7 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.8"
+        "php": "7.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.2"
+            "php": "7.4"
         }
     },
     "require": {


### PR DESCRIPTION
composer v2.0 is now out, and `dg/composer-cleaner` requires updating to the latest version to support that.
Update the PHP  dependencies:
```
$ composer update
Updating dependencies
Lock file operations: 0 installs, 3 updates, 0 removals
  - Upgrading aws/aws-sdk-php (3.158.14 => 3.158.18)
  - Upgrading dg/composer-cleaner (v2.1 => v2.2)
  - Upgrading symfony/polyfill-mbstring (v1.19.0 => v1.20.0)
Writing lock file
```

And `behat` dependencies with composer 2.0 only work with PHP 7.4. Set the acceptance test runner to use PHP 7.4.

Part of issue https://github.com/owncloud/core/issues/38067