### PR TITLE
[tests-only] skip core app-required scenarios

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -93,6 +93,7 @@ config = {
 			'cephS3': True,
 			'emailNeeded': True,
 			'federatedServerNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 			'runCoreTests': True,
 			'runAllSuites': True,
 			'numberOfParts': 27,
@@ -107,6 +108,7 @@ config = {
 			'cephS3': True,
 			'emailNeeded': True,
 			'federatedServerNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 			'runCoreTests': True,
 			'runAllSuites': True,
 			'numberOfParts': 27,
@@ -121,6 +123,7 @@ config = {
 			],
 			'cephS3': True,
 			'federatedServerNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 			'runCoreTests': True,
 			'runAllSuites': True,
 			'numberOfParts': 32,
@@ -134,6 +137,7 @@ config = {
 			],
 			'cephS3': True,
 			'federatedServerNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 			'runCoreTests': True,
 			'runAllSuites': True,
 			'numberOfParts': 32,
@@ -148,6 +152,7 @@ config = {
 			],
 			'scalityS3': True,
 			'federatedServerNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 			'runCoreTests': True,
 			'runAllSuites': True,
 			'numberOfParts': 32,
@@ -156,7 +161,7 @@ config = {
 			'suites': {
 				'apiAll': 'api-scality-remote' ,
 			},
-			'filterTags': '@smokeTest',
+			'filterTags': '@smokeTest&&~@skip&&~@app-required',
 			'servers': [
 				'daily-master-qa'
 			],


### PR DESCRIPTION
Any core test scenario that is tagged `@app-required` is a test scenario that needs some non-core app to be installed and enabled. To run those scenarios requires that CI have code to install and enable the needed app(s).

For pipelines that do a general run of core scenarios, skip those scenarios.