### PR TITLE
[tests-only] Test with mysql 8.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1572,7 +1572,7 @@ def databaseServiceForFederation(db, suffix):
 		print('Not implemented federated database for ', dbName)
 		return []
 
-	return [{
+	service = {
 		'name': dbName + suffix,
 		'image': db,
 		'pull': 'always',
@@ -1582,4 +1582,7 @@ def databaseServiceForFederation(db, suffix):
 			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
 			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 		}
-	}]
+	}
+	if (db == 'mysql:8.0'):
+		service['command'] = ['--default-authentication-plugin=mysql_native_password']
+	return [service]

--- a/.drone.star
+++ b/.drone.star
@@ -715,7 +715,7 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mysql:8.0', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,


### PR DESCRIPTION
mysql 5.5 is very old, mysql 5.7 is also no longer in the supported list https://doc.owncloud.com/server/10.6/admin_manual/installation/system_requirements.html

Test with mySQL 8.0, which is the official supported mySQL version.