### PR TITLE
[tests-only] Add test pipelines for scality ring 8

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -157,9 +157,9 @@ config = {
 			'runAllSuites': True,
 			'numberOfParts': 32,
 		},
-		'api-scality-remote-smoke': {
+		'api-scality7-remote-smoke': {
 			'suites': {
-				'apiAll': 'api-scality-remote' ,
+				'apiAll': 'api-scal7-remote' ,
 			},
 			'filterTags': '@smokeTest&&~@skip&&~@app-required',
 			'servers': [
@@ -224,10 +224,88 @@ config = {
 			'extraEnvironment': {
 				'S3_TYPE': 'scality',
 			},
+			'scalityS3': True,
 			'federatedServerNeeded': True,
 			'runCoreTests': True,
 			'runAllSuites': True,
-			'numberOfParts': 32,
+			'numberOfParts': 8,
+		},
+		'api-scality8-remote-smoke': {
+			'suites': {
+				'apiAll': 'api-scal8-remote' ,
+			},
+			'filterTags': '@smokeTest&&~@skip&&~@app-required',
+			'servers': [
+				'daily-master-qa'
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.2',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server/apps/files_primary_s3',
+						'cp tests/drone/scality.config.php /var/www/owncloud/server/config',
+						'sed -i -e "s/owncloud/owncloud-acceptance-tests-$DRONE_BUILD_NUMBER-$DRONE_STAGE_NUMBER/" /var/www/owncloud/server/config/scality.config.php',
+						'sed -i -e "s/accessKey1/$SCALITY_KEY/" /var/www/owncloud/server/config/scality.config.php',
+						'sed -i -e "s/verySecretKey1/$SCALITY_SECRET_ESCAPED/" /var/www/owncloud/server/config/scality.config.php',
+						'sed -i -e "s/http/https/" /var/www/owncloud/server/config/scality.config.php',
+						'sed -i -e "s/scality:8000/s3-b.isv.scality.com/" /var/www/owncloud/server/config/scality.config.php',
+						'cd /var/www/owncloud/server/',
+						'php occ s3:create-bucket owncloud-acceptance-tests-$DRONE_BUILD_NUMBER-$DRONE_STAGE_NUMBER --accept-warning',
+						'cd /var/www/owncloud/testrunner/apps/files_primary_s3',
+					],
+					'environment': {
+						'SCALITY_KEY': {
+							'from_secret': 'scality_access_key_ring_8'
+						},
+						'SCALITY_SECRET': {
+							'from_secret': 'scality_secret_access_key_ring_8'
+						},
+						'SCALITY_SECRET_ESCAPED': {
+							'from_secret': 'scality_secret_access_key_ring_8_escaped'
+						},
+					}
+				}
+			],
+			'extraTeardown': [
+				{
+					'name': 'cleanup-scality-bucket',
+					'image': 'banst/awscli',
+					'pull': 'always',
+					'failure': 'ignore',
+					'commands': [
+						'aws configure set aws_access_key_id $SCALITY_KEY',
+						'aws configure set aws_secret_access_key $SCALITY_SECRET',
+						'aws --endpoint-url $SCALITY_ENDPOINT s3 rm --recursive s3://owncloud-acceptance-tests-$DRONE_BUILD_NUMBER-$DRONE_STAGE_NUMBER',
+						'/var/www/owncloud/testrunner/apps/files_primary_s3/tests/delete_all_object_versions.sh $SCALITY_ENDPOINT owncloud-acceptance-tests-$DRONE_BUILD_NUMBER-$DRONE_STAGE_NUMBER',
+						'aws --endpoint-url $SCALITY_ENDPOINT s3 rb --force s3://owncloud-acceptance-tests-$DRONE_BUILD_NUMBER-$DRONE_STAGE_NUMBER',
+					],
+					'environment': {
+						'SCALITY_KEY': {
+							'from_secret': 'scality_access_key_ring_8'
+						},
+						'SCALITY_SECRET': {
+							'from_secret': 'scality_secret_access_key_ring_8'
+						},
+						'SCALITY_ENDPOINT': 'https://s3-b.isv.scality.com',
+					},
+					'when': {
+						'status': [
+							'failure',
+							'success',
+						],
+					},
+				}
+			],
+			'extraEnvironment': {
+				'S3_TYPE': 'scality',
+			},
+			'scalityS3': True,
+			'federatedServerNeeded': True,
+			'runCoreTests': True,
+			'runAllSuites': True,
+			'numberOfParts': 8,
 		},
 	}
 }


### PR DESCRIPTION
Fixes #427 

Adds a set of drone pipelines to run tests against a new scality "ring 8" server that has been provided for us to test against. We are already testing against a scality "ring 7" server, which we continue to do.

PR #433 demonstrates running the full set of core API tests successfully.

This PR just runs the smoke tests, the same as we do for "ring 7". They cover enough of the API usage to verify that a back-end storage is working nicely.

The authentication to the new "ring 8" storage is stored in secrets in the drone server settings https://drone.owncloud.com/owncloud/files_primary_s3/settings

scality_access_key_ring_8
scality_secret_access_key_ring_8
scality_secret_access_key_ring_8_escaped

The value of `scality_secret_access_key_ring_8` had some special characters that needed to be escaped with `\` in order to feed them to a `sed` replace command in CI. It is easier to save the escaped string into a separate secret, rather than writing code to escape it on-the-fly. That also reduces the chance that the escaped value might be displayed in the drone logs.