### PR TITLE
[tests-only] skip changed webUI AdminStorage Settings tests on old oC10

### DIFF
--- a/tests/acceptance/features/webUIFilesPrimaryS3/webUIFilesPrimaryS3.feature
+++ b/tests/acceptance/features/webUIFilesPrimaryS3/webUIFilesPrimaryS3.feature
@@ -4,7 +4,7 @@ Feature: Files Primary S3
   I want to run tests on s3 storage
   So that I can assert tests run the same on every storages
 
-  @issue-36803 @issue-files_primary_s3-351
+  @issue-36803 @issue-files_primary_s3-351 @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: applicable user is able to share top-level of read-only storage
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
PR https://github.com/owncloud/core/pull/38795 enhanced the way that the admin storage settings UI works. So the test scenario will no longer work against an old oC10. (There is a new element on the page is only there from oC10.8 onwards). Skip the test scenario on old oC10.

For example https://drone.owncloud.com/owncloud/files_primary_s3/2291/20/13

Note: the scenario here in files_primary_s3 is "a good thing" because it demonstrates the different (better) behavior in files_primary_s3 of core issue https://github.com/owncloud/core/issues/36803