### PR TITLE
[CI] disable crsf on server if federated server is needed

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1243,7 +1243,7 @@ def acceptance(ctx):
 						(installFederated(testConfig['server'], testConfig['phpVersion'], testConfig['logLevel'], testConfig['database'], federationDbSuffix) + owncloudLog('federated') if testConfig['federatedServerNeeded'] else []) +
 						installApp(ctx, testConfig['phpVersion']) +
 						installExtraApps(testConfig['phpVersion'], testConfig['extraApps']) +
-						setupServerAndApp(ctx, testConfig['phpVersion'], testConfig['logLevel']) +
+						setupServerAndApp(ctx, testConfig['phpVersion'], testConfig['logLevel'], testConfig['federatedServerNeeded']) +
 						owncloudLog('server') +
 						setupCeph(testConfig['cephS3']) +
 						setupScality(testConfig['scalityS3']) +
@@ -1786,7 +1786,7 @@ def installApp(ctx, phpVersion):
 		]
 	}]
 
-def setupServerAndApp(ctx, phpVersion, logLevel):
+def setupServerAndApp(ctx, phpVersion, logLevel, federatedServerNeeded = False):
 	return [{
 		'name': 'setup-server-%s' % ctx.repo.name,
 		'image': 'owncloudci/php:%s' % phpVersion,
@@ -1799,6 +1799,7 @@ def setupServerAndApp(ctx, phpVersion, logLevel):
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',
 			'php occ log:manage --level %s' % logLevel,
+			'php occ config:system:set csrf.disabled --value=true' if federatedServerNeeded else '',
 		]
 	}]
 


### PR DESCRIPTION
### Description
`csrf` is disabled on the server if the federated server is needed 

### Related Issue
- FIxes https://github.com/owncloud/files_primary_s3/issues/466