### PR TITLE
Add a warning that encryption is not compatible and might break things

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,4 +33,7 @@ This extension is the successor of the [ownCloud Objectstore App](https://market
 		<command>OCA\Files_Primary_S3\Command\s3List</command>
 		<command>OCA\Files_Primary_S3\Command\createBucket</command>
 	</commands>
+	<settings>
+		<admin>OCA\Files_Primary_S3\Panels\Admin</admin>
+	</settings>
 </info>

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,0 +1,3 @@
+#encryptionAPI .warning {
+    margin-bottom: 10px;
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,3 @@
+ $(document).ready(function () {
+	$(this).find('.warning').insertBefore('#enable');
+});

--- a/lib/Panels/Admin.php
+++ b/lib/Panels/Admin.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Primary_S3\Panels;
+
+use OCP\Settings\ISettings;
+use OCP\Template;
+use OCP\IConfig;
+
+class Admin implements ISettings {
+
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getPriority() {
+		return 0;
+	}
+
+	public function getSectionID() {
+		return 'encryption';
+	}
+
+	public function getPanel() {
+		$objectstore = $this->config->getSystemValue('objectstore', null);
+		if ($objectstore) {
+			$tmpl = new Template('files_primary_s3', 'settings');
+			return $tmpl;
+		}
+
+		return null;
+	}
+}

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+script('files_primary_s3', 'settings');
+style('files_primary_s3', 'settings');
+?>
+
+<div class="section" id="encryptionAPI">
+	<div class="warning">
+		<?php p($l->t('S3 Object Storage is currently not compatible with encryption, enabling might cause data-loss.')); ?>
+	</div>
+</div>


### PR DESCRIPTION
This information was initially mentioned in the docs, but got lost over time. See https://github.com/owncloud/docs/issues/4033.

Related to https://github.com/owncloud/core/issues/39263.

![image](https://user-images.githubusercontent.com/50302941/134512364-a4abef61-12ca-4b8b-8d1b-0c99b6bfb292.png)
