### PR TITLE
[donot-merge]Just check if notification enabled works

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -61,6 +61,11 @@ config = {
             },
             "includeKeyInMatrixName": True,
             "coverage": True,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
         "scality": {
             "phpVersions": [
@@ -74,6 +79,11 @@ config = {
             },
             "includeKeyInMatrixName": True,
             "coverage": False,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
         "scality-multibucket-cov": {
             "phpVersions": [
@@ -88,6 +98,11 @@ config = {
             },
             "includeKeyInMatrixName": True,
             "coverage": True,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
         "scality-multibucket": {
             "phpVersions": [
@@ -102,6 +117,11 @@ config = {
             },
             "includeKeyInMatrixName": True,
             "coverage": False,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
         "ceph-cov": {
             "phpVersions": [
@@ -113,6 +133,11 @@ config = {
             "cephS3": True,
             "includeKeyInMatrixName": True,
             "coverage": True,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
         "ceph": {
             "phpVersions": [
@@ -124,6 +149,11 @@ config = {
             "cephS3": True,
             "includeKeyInMatrixName": True,
             "coverage": False,
+            "extraCommandsBeforeTestRun": [
+                "cd %s" % dir["server"],
+                "php occ a:disable notifications",
+                "cd %s/apps/files_primary_s3" % dir["server"],
+            ],
         },
     },
     "acceptance": {


### PR DESCRIPTION
This is just for the check if the tests run when notification app is disabled since while auto-loading, as notification app is enabled and the tests uses the core bootstrap for auto-loading  `Class 'OCA\Notifications\Tests\Unit\TestCase'` class is not found.

So trying to run tests without the `notification` app