### PR TITLE
[tests-only] Drop Scality Artesca from CI (issue 564)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -263,35 +263,6 @@ config = {
                 "files_external": "",
             },
         },
-        "api-scality-artesca-remote-smoke": {
-            "suites": {
-                "apiAll": "api-scal-art-remote",
-            },
-            "filterTags": "@smokeTest&&~@skip&&~@app-required",
-            "servers": [
-                "daily-master-qa",
-            ],
-            "externalScality": {
-                "secrets": {
-                    "scality_key": "scality_access_key_artesca",
-                    "scality_secret": "scality_secret_access_key_artesca",
-                    "scality_secret_escaped": "scality_secret_access_key_artesca_escaped",
-                },
-                "externalServerUrl": "artesca.isv.scality.com",
-            },
-            "extraEnvironment": {
-                "S3_TYPE": "scality",
-            },
-            "scalityS3": True,
-            "federatedServerNeeded": True,
-            "runCoreTests": True,
-            "runAllSuites": True,
-            "numberOfParts": 4,
-            "cron": "nightly",
-            "extraApps": {
-                "files_external": "",
-            },
-        },
     },
 }
 


### PR DESCRIPTION
The Artesca Scality S3 test server is unavailable and we are getting no response about it - see issue #564 
So it fails every night in CI.

Drop it from CI. We can easily add it again if the provider gets it going.