### PR TITLE
[tests-only] Update ring8 and artesca tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -263,6 +263,35 @@ config = {
                 "files_external": "",
             },
         },
+        "api-scality-artesca-remote-smoke": {
+            "suites": {
+                "apiAll": "api-scal-art-remote",
+            },
+            "filterTags": "@smokeTest&&~@skip&&~@app-required",
+            "servers": [
+                "daily-master-qa",
+            ],
+            "externalScality": {
+                "secrets": {
+                    "scality_key": "scality_access_key_artesca",
+                    "scality_secret": "scality_secret_access_key_artesca",
+                    "scality_secret_escaped": "scality_secret_access_key_artesca_escaped",
+                },
+                "externalServerUrl": "artesca.isv.scality.com",
+            },
+            "extraEnvironment": {
+                "S3_TYPE": "scality",
+            },
+            "scalityS3": True,
+            "federatedServerNeeded": True,
+            "runCoreTests": True,
+            "runAllSuites": True,
+            "numberOfParts": 4,
+            "cron": "nightly",
+            "extraApps": {
+                "files_external": "",
+            },
+        },
     },
 }
 

--- a/.drone.star
+++ b/.drone.star
@@ -248,7 +248,7 @@ config = {
                     "scality_secret": "scality_secret_access_key_ring_8",
                     "scality_secret_escaped": "scality_secret_access_key_ring_8_escaped",
                 },
-                "externalServerUrl": "s3-b.isv.scality.com",
+                "externalServerUrl": "s3.isv.scality.com",
             },
             "extraEnvironment": {
                 "S3_TYPE": "scality",


### PR DESCRIPTION
Issue #564 

I updated the access keys in the secrets of https://drone.owncloud.com/owncloud/files_primary_s3/settings/secrets

This PR:
- adjusts the URL for s3.isv.scality.com
- puts back the Artesca nightly CI pipelines - reverts PR #575 

If we merge this PR, then we will find out overnight if it really works.