### PR TITLE
Allow configurable concurrent uploads

### DIFF
--- a/lib/s3storage.php
+++ b/lib/s3storage.php
@@ -31,7 +31,7 @@ use Aws\Handler\GuzzleV6\GuzzleHandler;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\ObjectUploader;
 use Aws\S3\S3Client;
-use GuzzleHttp\Handler\StreamHandler;
+use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Middleware;
 use OC\ServiceUnavailableException;
 use OCP\Files\ObjectStore\IObjectStore;
@@ -93,7 +93,7 @@ class S3Storage implements IObjectStore, IVersionedObjectStorage {
 			 * So various things that phan reports for this Guzzle5 code have to be suppressed.
 			*/
 			/* @phan-suppress-next-line PhanUndeclaredClassMethod */
-			$client = new \GuzzleHttp\Client(['handler' => new \GuzzleHttp\Ring\Client\StreamHandler()]);
+			$client = new \GuzzleHttp\Client(['handler' => new \GuzzleHttp\Ring\Client\CurlMultiHandler()]);
 			/* @phan-suppress-next-line PhanDeprecatedFunction */
 			$emitter = $client->getEmitter();
 			/* @phan-suppress-next-line PhanUndeclaredTypeParameter */
@@ -116,7 +116,7 @@ class S3Storage implements IObjectStore, IVersionedObjectStorage {
 			$h = new \Aws\Handler\GuzzleV5\GuzzleHandler($client);
 		} else {
 			// Create a handler stack that has all of the default middlewares attached
-			$handler = \GuzzleHttp\HandlerStack::create(new StreamHandler());
+			$handler = \GuzzleHttp\HandlerStack::create(new CurlMultiHandler());
 			// Push the handler onto the handler stack
 			$handler->push(Middleware::mapRequest(function (RequestInterface $request) {
 				if ($request->getMethod() !== 'PUT') {
@@ -175,6 +175,9 @@ class S3Storage implements IObjectStore, IVersionedObjectStorage {
 		}
 		if (isset($this->params['part_size'])) {
 			$opt['part_size'] = $this->params['part_size'];
+		}
+		if (isset($this->params['concurrency'])) {
+			$opt['concurrency'] = $this->params['concurrency'];
 		}
 
 		$uploader = new ObjectUploader($this->connection, $this->getBucket(), $urn, $stream, 'private', $opt);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,6 @@ parameters:
      - '#Method OCA\\Files_Primary_S3\\Panels\\Admin::getPanel\(\) should return OCP\\AppFramework\\Http\\TemplateResponse|OCP\\Template but returns null.#'
      - '#Comparison operation ">=" between 7 and 7 is always true.#'
      - '#Call to an undefined method GuzzleHttp\\Client::getEmitter\(\).#'
-     - '#Instantiated class GuzzleHttp\\Ring\\Client\\StreamHandler not found.#'
+     - '#Instantiated class GuzzleHttp\\Ring\\Client\\CurlMultiHandler not found.#'
      - '#Parameter \$event of anonymous function has invalid typehint type GuzzleHttp\\Event\\BeforeEvent.#'
      - '#Call to method getRequest\(\) on an unknown class GuzzleHttp\\Event\\BeforeEvent.#'


### PR DESCRIPTION
Ref https://github.com/owncloud/enterprise/issues/5372

The `CurlMultiHandler` will be used instead of the old StreamHandler in order to support concurrent uploads to the s3 storage. Curl is mandatory, so there is no reason to switch back.

The number of concurrent requests can be adjusted via config.php file:
```
'objectstore' => [
        'class' => getenv('OWNCLOUD_OBJECTSTORE_CLASS'),
        'arguments' => [
          'bucket' => getenv('OWNCLOUD_OBJECTSTORE_BUCKET'),
          'autocreate' => getenv('OWNCLOUD_OBJECTSTORE_AUTOCREATE'),
          'part_size' => 52428800,
          'concurrency' => 4,   // <---------------
          'options' => [
            'endpoint' => getenv('OWNCLOUD_OBJECTSTORE_ENDPOINT'),
            'version' => getenv('OWNCLOUD_OBJECTSTORE_VERSION'),
            'region' => getenv('OWNCLOUD_OBJECTSTORE_REGION'),
            'use_path_style_endpoint' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') === 'true',
            'command.params' => [
              'PathStyle' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') === 'true',
            ],
            'credentials' => [
              'key'   => getenv('OWNCLOUD_OBJECTSTORE_KEY'),
              'secret'  => getenv('OWNCLOUD_OBJECTSTORE_SECRET'),
            ],
          ],
        ],
      ],
```
If no value is configured, the aws-sdk will choose one (3 requests by default)

To be checked with both guzzle 5 and 7