### PR TITLE
[tests-only] bump oC10 server pins from the drone CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -55,7 +55,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.10.0-qa",
+                "10.11.0-qa",
             ],
             "databases": [
                 "sqlite",
@@ -80,7 +80,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.10.0-qa",
+                "10.11.0-qa",
             ],
             "scalityS3": {
                 "config": "multibucket",
@@ -103,7 +103,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.10.0-qa",
+                "10.11.0-qa",
             ],
             "cephS3": True,
             "includeKeyInMatrixName": True,


### PR DESCRIPTION
## Description
Bump oc10 server version pins from the drone CI

Fixes: https://github.com/owncloud/files_primary_s3/issues/613

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
