### PR TITLE
Fix stream downloads

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
      - '#Method OCA\\Files_Primary_S3\\Panels\\Admin::getPanel\(\) should return OCP\\AppFramework\\Http\\TemplateResponse|OCP\\Template but returns null.#'
      - '#Comparison operation ">=" between 7 and 7 is always true.#'
      - '#Call to an undefined method GuzzleHttp\\Client::getEmitter\(\).#'
+     - '#Instantiated class GuzzleHttp\\Ring\\Client\\StreamHandler not found.#'
      - '#Instantiated class GuzzleHttp\\Ring\\Client\\CurlMultiHandler not found.#'
      - '#Parameter \$event of anonymous function has invalid typehint type GuzzleHttp\\Event\\BeforeEvent.#'
      - '#Call to method getRequest\(\) on an unknown class GuzzleHttp\\Event\\BeforeEvent.#'


### PR DESCRIPTION
**MOVED TO https://github.com/owncloud/files_primary_s3/pull/618** in order to make it part of the 1.4.0 release


Ref: https://github.com/owncloud/enterprise/issues/5372

Recent changes allowed concurrent uploads by using a curlMultiHandler. However, this is causing issues with the downloads because they aren't being streamed properly. Currently, with the curlMultiHandler, we need to download the whole file from S3 before starting sending it to the client. This is causing long delays in the client, which could hit timeouts, specially for big files.

In order to fix this issue, we'll use a different connection in order to handle the downloads. For downloads, we'll use the old streamHandler; for the rest of actions, the new curlMutilHandler. This way, the downloads will be streamed to the client as soon as possible, and we'll still have concurrent uploads.