### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/command/createbucket.php
+++ b/lib/command/createbucket.php
@@ -59,9 +59,9 @@ class createBucket extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$input->getOption('accept-warning')) {
 			$helper = new QuestionHelper();
 			$q = <<<EOS
@@ -108,6 +108,7 @@ EOS;
 				'Status' => 'Enabled',
 				'MFADelete' => 'Disabled']
 		]);
+		return 0;
 	}
 
 	private function getClient() {

--- a/lib/command/s3list.php
+++ b/lib/command/s3list.php
@@ -55,9 +55,9 @@ class s3List extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$client = $this->getClient();
 
 		$bucketName = $input->getArgument('bucket');
@@ -100,6 +100,7 @@ class s3List extends Command {
 				$this->printValue($output, $markers, ['Key', 'LastModified', 'VersionId', 'IsLatest']);
 			}
 		}
+		return 0;
 	}
 
 	private function getClient() {


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630