### PR TITLE
[full-ci] [tests-only] Run unit tests against core master, 10.13 and 10.12

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -77,7 +77,8 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.11.0-qa",
+                "10.12.0-qa",
+                "10.13.0-qa",
             ],
             "databases": [
                 "sqlite",
@@ -102,7 +103,8 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.11.0-qa",
+                "10.12.0-qa",
+                "10.13.0-qa",
             ],
             "scalityS3": {
                 "config": "multibucket",
@@ -125,7 +127,8 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.11.0-qa",
+                "10.12.0-qa",
+                "10.13.0-qa",
             ],
             "cephS3": True,
             "includeKeyInMatrixName": True,


### PR DESCRIPTION
For this repo we have been running the PHP unit tests with multiple core releases.
This PR bumps those core release versions to be up-to-date. It will run with core master, 10.13 and 10.12

PRs related to this in the past are https://github.com/owncloud/activity/pull/1122 https://github.com/owncloud/files_primary_s3/pull/589
