### PR TITLE
chore: drop Guzzle v5

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,27 +7,3 @@ parameters:
       message: '#Method OCA\\Files_Primary_S3\\Panels\\Admin::getPanel\(\) should return OCP\\AppFramework\\Http\\TemplateResponse|OCP\\Template but returns null.#'
       path: lib/Panels/Admin.php
       count: 1
-    -
-      message: '#Comparison operation ">=" between 7 and 7 is always true.#'
-      path: lib/s3storage.php
-      count: 1
-    -
-      message: '#Call to an undefined method GuzzleHttp\\Client::getEmitter\(\).#'
-      path: lib/s3storage.php
-      count: 1
-    -
-      message: '#Instantiated class GuzzleHttp\\Ring\\Client\\StreamHandler not found.#'
-      path: lib/s3storage.php
-      count: 1
-    -
-      message: '#Instantiated class GuzzleHttp\\Ring\\Client\\CurlMultiHandler not found.#'
-      path: lib/s3storage.php
-      count: 1
-    -
-      message: '#Parameter \$event of anonymous function has invalid type GuzzleHttp\\Event\\BeforeEvent.#'
-      path: lib/s3storage.php
-      count: 1
-    -
-      message: '#Call to method getRequest\(\) on an unknown class GuzzleHttp\\Event\\BeforeEvent.#'
-      path: lib/s3storage.php
-      count: 1


### PR DESCRIPTION
Guzzle 5 was dropped with 10.11 - min version of `files_primary_s3` is now 10.12