### PR TITLE
test: update core versions for PHP unit tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -76,8 +76,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.12.0-qa",
-                "10.13.0-qa",
+                "10.13.4-qa",
             ],
             "databases": [
                 "sqlite",
@@ -102,8 +101,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.12.0-qa",
-                "10.13.0-qa",
+                "10.13.4-qa",
             ],
             "scalityS3": {
                 "config": "multibucket",
@@ -126,8 +124,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.12.0-qa",
-                "10.13.0-qa",
+                "10.13.4-qa",
             ],
             "cephS3": True,
             "includeKeyInMatrixName": True,


### PR DESCRIPTION
Fixes #682 

ownCloud core have moved forward since we started running unit tests against 10.12 and 10.3

This PR updates the tests run in CI so that PHP unit tests are run against 10.13.4 (and the daily core master). That is what we really want to know is working.