### PR TITLE
chore(ci): run unit tests with core 10.15.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -76,7 +76,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.13.4-qa",
+                "10.15.0-qa",
             ],
             "databases": [
                 "sqlite",
@@ -101,7 +101,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.13.4-qa",
+                "10.15.0-qa",
             ],
             "scalityS3": {
                 "config": "multibucket",
@@ -124,7 +124,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.13.4-qa",
+                "10.15.0-qa",
             ],
             "cephS3": True,
             "includeKeyInMatrixName": True,


### PR DESCRIPTION
Fixes #687 

I tried using "latest" but that is the "real release" without test infrastructure built-in.
I tried using "latest-qa" but that does not exist - we don't provide a "latest-qa" that links to "10.15.0-qa".
See commits in #689 where I tries this.

For now, we need to keep putting the actual release version number in here. So I put "10.15.0-qa". We could sort out having a "latest-qa" always available, but I don't think that it is worth trying to sort all that out.