### PR TITLE
chore: bump version to 1.7.0 for ownCloud 11.0.0-rc1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ This extension is the successor of the [ownCloud Objectstore App](https://market
 	<bugs>https://github.com/owncloud/files_primary_s3/issues</bugs>
 	<repository type="git">https://github.com/owncloud/files_primary_s3.git</repository>
 	<author>ownCloud GmbH</author>
-	<version>1.6.0</version>
+	<version>1.7.0</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/files/external_storage/s3_compatible_object_storage_as_primary.html</admin>
 	</documentation>


### PR DESCRIPTION
Bumps the app version to 1.7.0 for the ownCloud 11.0.0-rc1 bundle. The existing v1.6.0/v1.6.1 tags are the oc10 line; master is already oc11-compatible (`max-version="11"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)