### PR TITLE
ci: add the release workflow so release-1.6.2 can be tagged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: files_primary_s3
+      artifact-glob: build/artifacts/appstore/files_primary_s3.tar.gz
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}


### PR DESCRIPTION
`release-1.6.2` is based on a tag that predates the Drone → GitHub Actions migration, so it carries no `.github/workflows` at all — pushing a `v*` tag would build and publish nothing.

This copies `release.yml` verbatim from `master`, with only `app-name` and `artifact-glob` adjusted for this app. The Makefile on this branch already implements the contract the reusable workflow drives — an overridable `sign=` command guarded by `ifdef CAN_SIGN`, and a `dist` target producing the tarball named in `artifact-glob` — so no build changes are needed. Action SHAs are unchanged from master, so they stay within the org allowlist.

Release job only: the test workflows are **not** ported, since this branch's CI is `.drone.star` and porting that is a separate concern.

Part of https://kiteworks.atlassian.net/browse/OC10-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)