### PR TITLE
chore: release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [1.7.2] - 2026-09-09
+
+### Changed
+- Repackaged so the release artifact contains only the app payload. The previous
+  release was published from the build working tree, so it shipped `.git/`,
+  `.github/`, `tests/`, `vendor-bin/` and `build/artifacts/` as part of the signed
+  app ([#41824](https://github.com/owncloud/core/issues/41824))
+
 ## [1.7.1] - 2026-07-22
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ This extension is the successor of the [ownCloud Objectstore App](https://market
 	<bugs>https://github.com/owncloud/files_primary_s3/issues</bugs>
 	<repository type="git">https://github.com/owncloud/files_primary_s3.git</repository>
 	<author>ownCloud GmbH</author>
-	<version>1.7.1</version>
+	<version>1.7.2</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/files/external_storage/s3_compatible_object_storage_as_primary.html</admin>
 	</documentation>


### PR DESCRIPTION
Repackaging release, part of the remediation for owncloud/core#41824.

## Why

The `files_primary_s3` asset published for the previous version was uploaded from the **build working tree** rather than from `build/artifacts/appstore/files_primary_s3.tar.gz`. It therefore shipped `.git/`, `.github/`, `tests/`, `vendor-bin/` and `build/artifacts/` as part of the signed app.

Because those files are covered by `appinfo/signature.json`, an administrator cannot delete them without breaking `occ integrity:check-app` — so the only fix is a new release built by CI.

## What this does

Bumps `appinfo/info.xml` to `1.7.2` and adds the changelog entry. **No functional change.**

Tagging `v1.7.2` lets `.github/workflows/release.yml` publish the packaged artifact. That workflow now also asserts the tarball is free of development files (owncloud/reusable-workflows#97), so this class of problem cannot recur silently.

## Merging

The `release.yml` workflow asserts the tag matches `appinfo/info.xml`, so merge this **before** pushing `v1.7.2`.

Once published, the new tag gets repinned in the ownCloud 11.0.1 bundle specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)